### PR TITLE
Make inequality in rolling_origin's row check strict.

### DIFF
--- a/R/rolling_origin.R
+++ b/R/rolling_origin.R
@@ -39,7 +39,7 @@ rolling_origin <- function(data, initial = 5, assess = 1,
                            cumulative = TRUE, skip = 0, ...) {
   n <- nrow(data)
 
-  if (n <= initial + assess)
+  if (n < initial + assess)
     stop("There should be at least ",
          initial + assess,
          " nrows in `data`",


### PR DESCRIPTION
Closes #54.

It was such a small fix I wasn't sure if a new test case was worth it; happy to add one, though.