### PR TITLE
Add context() calls to all test files

### DIFF
--- a/tests/testthat/test_boot.R
+++ b/tests/testthat/test_boot.R
@@ -1,3 +1,5 @@
+context("Bootstrapping")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -8,13 +10,13 @@ test_that('default param', {
   set.seed(11)
   rs1 <- bootstraps(dat1)
   sizes1 <- rsample:::dim_rset(rs1)
-  
+
   expect_true(all(sizes1$analysis == nrow(dat1)))
   same_data <-
     map_lgl(rs1$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs1$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -25,7 +27,7 @@ test_that('default param', {
 test_that('apparent', {
   rs2 <- bootstraps(dat1, apparent = TRUE)
   sizes2 <- rsample:::dim_rset(rs2)
-  
+
   expect_true(all(sizes2$analysis == nrow(dat1)))
   expect_true(all(sizes2$assessment[nrow(sizes2)] == nrow(dat1)))
   expect_equal(sizes2$assessment[sizes2$id == "Apparent"], nrow(dat1))
@@ -40,7 +42,7 @@ test_that('strata', {
   set.seed(11)
   rs4 <- bootstraps(iris2,  strata = "Species")
   sizes4 <- rsample:::dim_rset(rs4)
-  
+
   expect_true(all(sizes4$analysis == nrow(iris2)))
 
   rate <- map_dbl(rs4$splits,
@@ -49,30 +51,30 @@ test_that('strata', {
                     mean(dat == "virginica")
                   })
   expect_true(length(unique(rate)) == 1)
-  
+
   good_holdout <- map_lgl(rs4$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
                           })
   expect_true(all(good_holdout))
-  
+
   rs5 <- bootstraps(iris2, apparent = TRUE, strata = "Species")
   sizes5 <- rsample:::dim_rset(rs5)
-  
+
   expect_true(all(sizes5$analysis == nrow(iris2)))
   expect_true(all(sizes5$assessment[nrow(sizes5)] == nrow(iris2)))
   expect_equal(sizes5$assessment[sizes5$id == "Apparent"], nrow(iris2))
   res5 <-
     as.data.frame(rs5$splits[[nrow(sizes5)]], data = "assessment")
   expect_equal(res5, iris2)
-  
+
 })
 
 
 test_that('bad args', {
   expect_error(bootstraps(iris, strata = iris$Species))
-  expect_error(bootstraps(iris, strata = 2))  
-  expect_error(bootstraps(iris, strata = c("Species", "Species")))  
+  expect_error(bootstraps(iris, strata = 2))
+  expect_error(bootstraps(iris, strata = c("Species", "Species")))
 })
 
 

--- a/tests/testthat/test_caret.R
+++ b/tests/testthat/test_caret.R
@@ -1,3 +1,5 @@
+context("Conversions for caret")
+
 library(testthat)
 library(rsample)
 
@@ -6,7 +8,7 @@ library(rsample)
 
 dat <- data.frame(y = 1:15, x = 15:1)
 
-lgo1 <- 
+lgo1 <-
   structure(
     list(
       method = "LGOCV",
@@ -58,7 +60,7 @@ cv_1 <- structure(
   .Names = c("method", "index", "indexOut", "number", "repeats")
 )
 
-cv_2 <- 
+cv_2 <-
   structure(
   list(
     method = "repeatedcv",
@@ -99,7 +101,7 @@ cv_2 <-
 cv_3 <- cv_2
 cv_3$method <- "adaptive_cv"
 
-bt_1 <- 
+bt_1 <-
   structure(
     list(
       method = "boot",
@@ -134,7 +136,7 @@ bt_4$method <- "boot_all"
 bt_5 <- bt_1
 bt_5$method <- "adaptive_boot"
 
-loo_1 <- 
+loo_1 <-
   structure(
     list(
       method = "LOOCV",
@@ -184,7 +186,7 @@ loo_1 <-
     .Names = c("method", "index", "indexOut")
   )
 
-rof_1 <- 
+rof_1 <-
   structure(
     list(
       method = "timeSlice",
@@ -237,74 +239,74 @@ check_indices <- function(newer, orig) {
 test_that('basic v-fold', {
   vfold_obj_1 <- caret2rsample(cv_1, data = dat)
   check_indices(vfold_obj_1, cv_1)
-  for (i in seq_along(vfold_obj_1$splits)) 
-    expect_equal(vfold_obj_1$id[[i]], names(cv_1$index)[i]) 
+  for (i in seq_along(vfold_obj_1$splits))
+    expect_equal(vfold_obj_1$id[[i]], names(cv_1$index)[i])
 })
 
 test_that('repeated v-fold', {
   vfold_obj_2 <- caret2rsample(cv_2, data = dat)
   check_indices(vfold_obj_2, cv_2)
-  for (i in seq_along(vfold_obj_2$splits)) 
-    expect_equal(paste(vfold_obj_2$id2[[i]], vfold_obj_2$id[[i]], 
+  for (i in seq_along(vfold_obj_2$splits))
+    expect_equal(paste(vfold_obj_2$id2[[i]], vfold_obj_2$id[[i]],
                        sep = "."),
-                 names(cv_2$index)[i]) 
-  
+                 names(cv_2$index)[i])
+
 })
 
 test_that('basic boot', {
   bt_obj_1 <- caret2rsample(bt_1, data = dat)
   check_indices(bt_obj_1, bt_1)
-  for (i in seq_along(bt_obj_1$splits)) 
-    expect_equal(bt_obj_1$id[[i]], names(bt_1$index)[i]) 
+  for (i in seq_along(bt_obj_1$splits))
+    expect_equal(bt_obj_1$id[[i]], names(bt_1$index)[i])
 })
 
 test_that('boot 632', {
   bt_obj_2 <- caret2rsample(bt_2, data = dat)
   check_indices(bt_obj_2, bt_2)
-  for (i in seq_along(bt_obj_2$splits)) 
-    expect_equal(bt_obj_2$id[[i]], names(bt_2$index)[i]) 
+  for (i in seq_along(bt_obj_2$splits))
+    expect_equal(bt_obj_2$id[[i]], names(bt_2$index)[i])
 })
 
 test_that('boot optim', {
   bt_obj_3 <- caret2rsample(bt_3, data = dat)
   check_indices(bt_obj_3, bt_3)
-  for (i in seq_along(bt_obj_3$splits)) 
-    expect_equal(bt_obj_3$id[[i]], names(bt_3$index)[i]) 
+  for (i in seq_along(bt_obj_3$splits))
+    expect_equal(bt_obj_3$id[[i]], names(bt_3$index)[i])
 })
 
 test_that('boot all', {
   bt_obj_4 <- caret2rsample(bt_4, data = dat)
   check_indices(bt_obj_4, bt_4)
-  for (i in seq_along(bt_obj_4$splits)) 
-    expect_equal(bt_obj_4$id[[i]], names(bt_4$index)[i]) 
+  for (i in seq_along(bt_obj_4$splits))
+    expect_equal(bt_obj_4$id[[i]], names(bt_4$index)[i])
 })
 
 test_that('adaptive boot', {
   bt_obj_5 <- caret2rsample(bt_5, data = dat)
   check_indices(bt_obj_5, bt_5)
-  for (i in seq_along(bt_obj_5$splits)) 
-    expect_equal(bt_obj_5$id[[i]], names(bt_5$index)[i]) 
+  for (i in seq_along(bt_obj_5$splits))
+    expect_equal(bt_obj_5$id[[i]], names(bt_5$index)[i])
 })
 
 
 test_that('loo', {
   loo_obj <- caret2rsample(loo_1, data = dat)
   check_indices(loo_obj, loo_1)
-  for (i in seq_along(loo_obj$splits)) 
-    expect_equal(loo_obj$id[[i]], names(loo_1$index)[i]) 
+  for (i in seq_along(loo_obj$splits))
+    expect_equal(loo_obj$id[[i]], names(loo_1$index)[i])
 })
 
 test_that('mcv', {
   mcv_obj <- caret2rsample(lgo1, data = dat)
   check_indices(mcv_obj, lgo1)
-  for (i in seq_along(mcv_obj$splits)) 
-    expect_equal(mcv_obj$id[[i]], names(lgo1$index)[i]) 
+  for (i in seq_along(mcv_obj$splits))
+    expect_equal(mcv_obj$id[[i]], names(lgo1$index)[i])
 })
 
 test_that('rolling origin', {
   rof_obj <- caret2rsample(rof_1, data = dat)
   check_indices(rof_obj, rof_1)
-  for (i in seq_along(rof_obj$splits)) 
-    expect_equal(rof_obj$id[[i]], names(rof_1$index)[i]) 
+  for (i in seq_along(rof_obj$splits))
+    expect_equal(rof_obj$id[[i]], names(rof_1$index)[i])
 })
 

--- a/tests/testthat/test_dplyr.R
+++ b/tests/testthat/test_dplyr.R
@@ -1,3 +1,5 @@
+context("Compatibility with dplyr")
+
 library(rsample)
 library(testthat)
 library(dplyr)
@@ -21,7 +23,7 @@ check_att <- function(x, y)
 
 test_that('object types', {
   expect_true(rsample:::is_rset(obj_1))
-  expect_false(rsample:::is_rset(obj_1[, -1]))  
+  expect_false(rsample:::is_rset(obj_1[, -1]))
 })
 
 ###################################################################
@@ -32,101 +34,101 @@ test_that('dplyr ops', {
       obj_2 %>% filter(id == "Bootstrap02")
     )
   )
-  expect_true(  
+  expect_true(
     rsample:::is_rset(
       obj_3 %>% mutate(blah = substr(id, 1, 3))
-    )    
+    )
   )
-  expect_true(  
+  expect_true(
     rsample:::is_rset(
       obj_4 %>% select(splits, id)
-    )    
-  ) 
-  expect_true(  
+    )
+  )
+  expect_true(
     rsample:::is_rset(
       obj_1 %>% arrange(id)
-    )    
-  )   
-  expect_true(  
+    )
+  )
+  expect_true(
     rsample:::is_rset(
       obj_1 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  ) 
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_1 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_1 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_1
-    )    
-  )   
-  expect_true(  
+    )
+  )
+  expect_true(
     rsample:::is_rset(
       obj_2 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_2 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_2 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_2
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_3 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_3 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_3 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_3
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_4 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_4 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_4 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_4
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_5 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_5 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_5 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_5
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_6 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_6 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_6 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_6
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_7 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
-    )    
-  )  
-  expect_true(  
+    )
+  )
+  expect_true(
     check_att(
-      obj_7 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah), 
+      obj_7 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah),
       obj_7
     )
-  )  
-  expect_true(  
+  )
+  expect_true(
     rsample:::is_rset(
       obj_3 %>% slice(1L)
-    )    
-  )    
+    )
+  )
 })

--- a/tests/testthat/test_for_pred.R
+++ b/tests/testthat/test_for_pred.R
@@ -1,3 +1,5 @@
+context("Predictor extraction")
+
 library(testthat)
 
 test_that('no dots', {

--- a/tests/testthat/test_gather.R
+++ b/tests/testthat/test_gather.R
@@ -1,3 +1,5 @@
+context("Gather from tidyr")
+
 library(testthat)
 library(rsample)
 library(tidyr)

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -1,3 +1,5 @@
+context("Group resampling")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -10,10 +12,10 @@ get_id_left_out <- function(x)
 
 test_that('bad args', {
   expect_error(group_vfold_cv(iris, group = iris$Species))
-  expect_error(group_vfold_cv(iris, group = c("Species", "Sepal.Width")))  
-  expect_error(group_vfold_cv(iris, group = "Specie"))  
-  expect_error(group_vfold_cv(iris))    
-  expect_error(group_vfold_cv(iris, group = "Species", v = 10))  
+  expect_error(group_vfold_cv(iris, group = c("Species", "Sepal.Width")))
+  expect_error(group_vfold_cv(iris, group = "Specie"))
+  expect_error(group_vfold_cv(iris))
+  expect_error(group_vfold_cv(iris, group = "Species", v = 10))
 })
 
 
@@ -21,20 +23,20 @@ test_that('default param', {
   set.seed(11)
   rs1 <- group_vfold_cv(iris, "Species")
   sizes1 <- rsample:::dim_rset(rs1)
-  
+
   expect_true(all(sizes1$analysis == 100))
-  expect_true(all(sizes1$assessment == 50))  
+  expect_true(all(sizes1$assessment == 50))
   same_data <-
     map_lgl(rs1$splits, function(x)
       all.equal(x$data, iris))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs1$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
                           })
   expect_true(all(good_holdout))
-  
+
   sp_out <- map_chr(rs1$splits, get_id_left_out)
   expect_true(all(table(sp_out) == 1))
 })
@@ -44,20 +46,20 @@ test_that('v < max v', {
   set.seed(11)
   rs2 <- group_vfold_cv(iris, "Species", v = 2)
   sizes2 <- rsample:::dim_rset(rs2)
-  
+
   expect_true(!all(sizes2$analysis == 100))
-  expect_true(!all(sizes2$assessment == 50))  
+  expect_true(!all(sizes2$assessment == 50))
   same_data <-
     map_lgl(rs2$splits, function(x)
       all.equal(x$data, iris))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs2$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
                           })
   expect_true(all(good_holdout))
-  
+
   sp_out <- map(rs2$splits, get_id_left_out)
   expect_true(all(table(unlist(sp_out)) == 1))
 })
@@ -66,20 +68,20 @@ test_that('tibble input', {
   set.seed(11)
   rs3 <- group_vfold_cv(iris2, "Species")
   sizes3 <- rsample:::dim_rset(rs3)
-  
+
   expect_true(all(sizes3$analysis == 100))
-  expect_true(all(sizes3$assessment == 50))  
+  expect_true(all(sizes3$assessment == 50))
   same_data <-
     map_lgl(rs3$splits, function(x)
       all.equal(x$data, iris2))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs3$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
                           })
   expect_true(all(good_holdout))
-  
+
   sp_out <- map_chr(rs3$splits, get_id_left_out)
   expect_true(all(table(sp_out) == 1))
 })

--- a/tests/testthat/test_initial.R
+++ b/tests/testthat/test_initial.R
@@ -1,3 +1,5 @@
+context("Initial splitting")
+
 library(testthat)
 library(rsample)
 library(purrr)

--- a/tests/testthat/test_labels.R
+++ b/tests/testthat/test_labels.R
@@ -1,3 +1,5 @@
+context("Labels")
+
 library(testthat)
 library(rsample)
 
@@ -5,7 +7,7 @@ test_that('basic cv', {
   cv_obj <- vfold_cv(mtcars)
   expect_equal(cv_obj$id, labels(cv_obj))
   expect_is(labels(cv_obj), "character")
-  expect_s3_class(labels(cv_obj, TRUE), "factor")  
+  expect_s3_class(labels(cv_obj, TRUE), "factor")
 })
 
 test_that('repeated cv', {
@@ -13,14 +15,14 @@ test_that('repeated cv', {
   expect_equal(paste(rcv_obj$id, rcv_obj$id2, sep = "."),
                labels(rcv_obj))
   expect_is(labels(rcv_obj), "character")
-  expect_s3_class(labels(rcv_obj, TRUE), "factor")  
+  expect_s3_class(labels(rcv_obj, TRUE), "factor")
 })
 
 test_that('nested cv', {
   expect_error(
     labels(
-      nested_cv(mtcars, 
-                outside = vfold_cv(v = 3), 
+      nested_cv(mtcars,
+                outside = vfold_cv(v = 3),
                 inside = bootstraps(times = 5)
                 )
       )

--- a/tests/testthat/test_loo.R
+++ b/tests/testthat/test_loo.R
@@ -1,3 +1,5 @@
+context("Leave-one-out CV")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -8,21 +10,21 @@ test_that('Loooooo', {
 
   loo1 <- loo_cv(dat1)
   expect_equal(nrow(loo1), nrow(dat1))
-  
+
   same_data <-
     map_lgl(loo1$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   holdouts <-
     map_lgl(loo1$splits, function(x)
       length(x$out_id) == 1)
-  expect_true(all(holdouts)) 
-  
+  expect_true(all(holdouts))
+
   retained <-
     map_lgl(loo1$splits, function(x)
-      length(x$in_id) == (nrow(dat1) - 1))  
-  expect_true(all(retained))  
+      length(x$in_id) == (nrow(dat1) - 1))
+  expect_true(all(retained))
 })
 
 test_that('printing', {

--- a/tests/testthat/test_mc.R
+++ b/tests/testthat/test_mc.R
@@ -1,3 +1,5 @@
+context("Monte Carlo CV")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -8,14 +10,14 @@ test_that('default param', {
   set.seed(11)
   rs1 <- mc_cv(dat1)
   sizes1 <- rsample:::dim_rset(rs1)
-  
+
   expect_true(all(sizes1$analysis == 15))
-  expect_true(all(sizes1$assessment == 5))  
+  expect_true(all(sizes1$assessment == 5))
   same_data <-
     map_lgl(rs1$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs1$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -27,14 +29,14 @@ test_that('different percent', {
   set.seed(11)
   rs2 <- mc_cv(dat1, prop = .5)
   sizes2 <- rsample:::dim_rset(rs2)
-  
+
   expect_true(all(sizes2$analysis == 10))
-  expect_true(all(sizes2$assessment == 10))  
+  expect_true(all(sizes2$assessment == 10))
   same_data <-
     map_lgl(rs2$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs2$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -47,17 +49,17 @@ test_that('strata', {
   set.seed(11)
   rs3 <- mc_cv(iris2, strata = "Species")
   sizes3 <- rsample:::dim_rset(rs3)
-  
+
   expect_true(all(sizes3$analysis == 99))
-  expect_true(all(sizes3$assessment == 31))  
-  
+  expect_true(all(sizes3$assessment == 31))
+
   rate <- map_dbl(rs3$splits,
                   function(x) {
                     dat <- as.data.frame(x)$Species
                     mean(dat == "virginica")
                   })
   expect_true(length(unique(rate)) == 1)
-  
+
   good_holdout <- map_lgl(rs3$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -68,8 +70,8 @@ test_that('strata', {
 
 test_that('bad args', {
   expect_error(mc_cv(iris, strata = iris$Species))
-  expect_error(mc_cv(iris, strata = 2))  
-  expect_error(mc_cv(iris, strata = c("Species", "Species")))  
+  expect_error(mc_cv(iris, strata = 2))
+  expect_error(mc_cv(iris, strata = c("Species", "Species")))
 })
 
 

--- a/tests/testthat/test_names.R
+++ b/tests/testthat/test_names.R
@@ -1,10 +1,12 @@
+context("Naming functions")
+
 library(testthat)
 library(rsample)
 
 test_that('basic naming sequences', {
   expect_equal(rsample:::names0(2), c("x1", "x2"))
   expect_equal(rsample:::names0(2, "y"), c("y1", "y2"))
-  expect_equal(rsample:::names0(10), 
+  expect_equal(rsample:::names0(10),
                c(paste0("x0", 1:9), "x10"))
 })
 

--- a/tests/testthat/test_nesting.R
+++ b/tests/testthat/test_nesting.R
@@ -1,3 +1,5 @@
+context("Nested CV")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -9,34 +11,34 @@ test_that('default param', {
                    inside = vfold_cv(v = 3))
   sizes1 <- rsample:::dim_rset(rs1)
   expect_true(all(sizes1$analysis == 27))
-  expect_true(all(sizes1$assessment == 3))  
+  expect_true(all(sizes1$assessment == 3))
   subsizes1 <- map(rs1$inner_resamples, rsample:::dim_rset)
   subsizes1 <- do.call("rbind", subsizes1)
   expect_true(all(subsizes1$analysis == 18))
-  expect_true(all(subsizes1$assessment == 9)) 
-  
+  expect_true(all(subsizes1$assessment == 9))
+
   set.seed(11)
   rs2 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),
                    inside = bootstraps(times = 3))
   sizes2 <- rsample:::dim_rset(rs2)
   expect_true(all(sizes2$analysis == 27))
-  expect_true(all(sizes2$assessment == 3))  
+  expect_true(all(sizes2$assessment == 3))
   subsizes2 <- map(rs2$inner_resamples, rsample:::dim_rset)
   subsizes2 <- do.call("rbind", subsizes2)
   expect_true(all(subsizes2$analysis == 27))
-  
+
   set.seed(11)
   rs3 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),
                    inside = mc_cv(prop = 2/3, times = 3))
   sizes3 <- rsample:::dim_rset(rs3)
   expect_true(all(sizes3$analysis == 27))
-  expect_true(all(sizes3$assessment == 3))  
+  expect_true(all(sizes3$assessment == 3))
   subsizes3 <- map(rs3$inner_resamples, rsample:::dim_rset)
   subsizes3 <- do.call("rbind", subsizes3)
   expect_true(all(subsizes3$analysis == 18))
-  expect_true(all(subsizes3$assessment == 9))  
+  expect_true(all(subsizes3$assessment == 9))
 })
 
 test_that('bad args', {
@@ -50,7 +52,7 @@ test_that('bad args', {
     nested_cv(mtcars,
               outside = vfold_cv(),
               inside = folds)
-  )  
+  )
 })
 
 test_that('printing', {

--- a/tests/testthat/test_rolling.R
+++ b/tests/testthat/test_rolling.R
@@ -1,3 +1,5 @@
+context("Rolling window resampling")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -7,27 +9,27 @@ dat1 <- data.frame(a = 1:20, b = letters[1:20])
 test_that('default param', {
   rs1 <- rolling_origin(dat1)
   sizes1 <- rsample:::dim_rset(rs1)
-  
+
   expect_true(all(sizes1$assessment == 1))
   expect_true(all(sizes1$analysis == 5:19))
   same_data <-
     map_lgl(rs1$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   for (i in 1:nrow(rs1)) {
     expect_equal(rs1$splits[[i]]$in_id,
                  1:(i + attr(rs1, "initial") - 1))
     expect_equal(rs1$splits[[i]]$out_id,
                  i + attr(rs1, "initial"))
   }
-  
+
 })
 
 test_that('larger holdout', {
   rs2 <- rolling_origin(dat1, assess = 3)
   sizes2 <- rsample:::dim_rset(rs2)
-  
+
   expect_true(all(sizes2$assessment == 3))
   expect_true(all(sizes2$analysis == 5:17))
 
@@ -38,13 +40,13 @@ test_that('larger holdout', {
                  (i + attr(rs2, "initial")):
                    (i + attr(rs2, "initial") + attr(rs2, "assess") - 1))
   }
-  
+
 })
 
 test_that('fixed analysis size', {
   rs3 <- rolling_origin(dat1, cumulative = FALSE)
   sizes3 <- rsample:::dim_rset(rs3)
-  
+
   expect_true(all(sizes3$assessment == 1))
   expect_true(all(sizes3$analysis == 5))
 
@@ -54,14 +56,14 @@ test_that('fixed analysis size', {
     expect_equal(rs3$splits[[i]]$out_id,
                  i + attr(rs3, "initial"))
   }
-  
+
 })
 
 
 test_that('skipping', {
   rs4 <- rolling_origin(dat1, cumulative = FALSE, skip = 2)
   sizes4 <- rsample:::dim_rset(rs4)
-  
+
   expect_true(all(sizes4$assessment == 1))
   expect_true(all(sizes4$analysis == 5))
 
@@ -72,7 +74,7 @@ test_that('skipping', {
     expect_equal(rs4$splits[[i]]$out_id,
                  i + attr(rs4, "skip")*(i-1) + attr(rs4, "initial"))
   }
-  
+
 })
 
 test_that('printing', {

--- a/tests/testthat/test_rset.R
+++ b/tests/testthat/test_rset.R
@@ -1,3 +1,5 @@
+context("Rset constructor")
+
 library(testthat)
 library(rsample)
 

--- a/tests/testthat/test_rsplit.R
+++ b/tests/testthat/test_rsplit.R
@@ -1,3 +1,5 @@
+context("Rsplit constructor")
+
 library(testthat)
 library(rsample)
 
@@ -32,11 +34,11 @@ test_that('bad inputs', {
 test_that('as.data.frame', {
   rs3 <- rsample:::rsplit(dat1, 1:2, 4:5)
   expect_equal(as.data.frame(rs3), dat1[1:2,])
-  expect_equal(as.data.frame(rs3, data = "assessment"), dat1[4:5,])  
-  
+  expect_equal(as.data.frame(rs3, data = "assessment"), dat1[4:5,])
+
   rs4 <- rsample:::rsplit(dat1, rep(1:2, each = 3), rep(4:5, c(2, 1)))
   expect_equal(as.data.frame(rs4), dat1[c(1, 1, 1, 2, 2, 2),])
-  expect_equal(as.data.frame(rs4, data = "assessment"), dat1[c(4, 4, 5),])  
+  expect_equal(as.data.frame(rs4, data = "assessment"), dat1[c(4, 4, 5),])
 })
 
 

--- a/tests/testthat/test_strata.R
+++ b/tests/testthat/test_strata.R
@@ -1,3 +1,5 @@
+context("Strata constructor")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -8,10 +10,10 @@ test_that('simple numerics', {
   str1a <- make_strata(x1)
   tab1a <- table(str1a)
   expect_equal(as.vector(tab1a), rep(200, 5))
-  
+
   str1b <- make_strata(x1, depth = 500)
   tab1b <- table(str1b)
-  expect_equal(as.vector(tab1b), rep(500, 2))  
+  expect_equal(as.vector(tab1b), rep(500, 2))
 })
 
 test_that('simple character', {

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -1,3 +1,5 @@
+context("Tidy methods")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -16,7 +18,7 @@ test_that('simple boot', {
   set.seed(11)
   rs1 <- bootstraps(dat1)
   td1 <- tidy(rs1, unique_ind = FALSE)
-  
+
   name_vals <- rsample:::names0(nrow(rs1), "Bootstrap")
   for(i in 1:nrow(rs1)) {
     expect_true(
@@ -32,7 +34,7 @@ test_that('vfold', {
   set.seed(11)
   rs2 <- vfold_cv(dat1)
   td2 <- tidy(rs2, unique_ind = FALSE)
-  
+
   for(i in 1:nrow(rs2)) {
     expect_true(
       check_ind(rs2$splits[[i]],

--- a/tests/testthat/test_vfold.R
+++ b/tests/testthat/test_vfold.R
@@ -1,3 +1,5 @@
+context("V-fold CV")
+
 library(testthat)
 library(rsample)
 library(purrr)
@@ -8,14 +10,14 @@ test_that('default param', {
   set.seed(11)
   rs1 <- vfold_cv(dat1)
   sizes1 <- rsample:::dim_rset(rs1)
-  
+
   expect_true(all(sizes1$analysis == 18))
-  expect_true(all(sizes1$assessment == 2))  
+  expect_true(all(sizes1$assessment == 2))
   same_data <-
     map_lgl(rs1$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs1$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -27,14 +29,14 @@ test_that('repeated', {
   set.seed(11)
   rs2 <- vfold_cv(dat1, repeats = 4)
   sizes2 <- rsample:::dim_rset(rs2)
-  
+
   expect_true(all(sizes2$analysis == 18))
-  expect_true(all(sizes2$assessment == 2))  
+  expect_true(all(sizes2$assessment == 2))
   same_data <-
     map_lgl(rs2$splits, function(x)
       all.equal(x$data, dat1))
   expect_true(all(same_data))
-  
+
   good_holdout <- map_lgl(rs2$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -47,9 +49,9 @@ test_that('strata', {
   set.seed(11)
   rs3 <- vfold_cv(iris2, repeats = 2, strata = "Species")
   sizes3 <- rsample:::dim_rset(rs3)
-  
+
   expect_true(all(sizes3$analysis == 117))
-  expect_true(all(sizes3$assessment == 13))  
+  expect_true(all(sizes3$assessment == 13))
 
   rate <- map_dbl(rs3$splits,
                   function(x) {
@@ -57,7 +59,7 @@ test_that('strata', {
                     mean(dat == "virginica")
                   })
   expect_true(length(unique(rate)) == 1)
-  
+
   good_holdout <- map_lgl(rs3$splits,
                           function(x) {
                             length(intersect(x$in_ind, x$out_id)) == 0
@@ -68,8 +70,8 @@ test_that('strata', {
 
 test_that('bad args', {
   expect_error(vfold_cv(iris, strata = iris$Species))
-  expect_error(vfold_cv(iris, strata = 2))  
-  expect_error(vfold_cv(iris, strata = c("Species", "Species")))  
+  expect_error(vfold_cv(iris, strata = 2))
+  expect_error(vfold_cv(iris, strata = c("Species", "Species")))
 })
 
 test_that('printing', {
@@ -82,7 +84,7 @@ test_that('rsplit labels', {
   all_labs <- map_df(rs$splits, labels)
   original_id <- rs[, grepl("^id", names(rs))]
   expect_equal(all_labs, original_id)
-  
+
   rs2 <- vfold_cv(mtcars, repeats = 4)
   all_labs2 <- map_df(rs2$splits, labels)
   original_id2 <- rs2[, grepl("^id", names(rs2))]


### PR DESCRIPTION
Closes #60.

Test output now looks like this:
```
==> devtools::test()

Loading rsample
Loading required package: testthat
Loading required package: broom
Loading required package: tidyr
Testing rsample
✔ | OK F W S | Context
✔ | 19       | Bootstrapping [0.4 s]
✔ | 132       | Conversions for caret [0.1 s]
✔ | 21       | Compatibility with dplyr [0.1 s]
✔ | 22       | Predictor extraction
✔ |  6       | Gather from tidyr
✔ | 22       | Group resampling [0.1 s]
✔ |  3       | Initial splitting
✔ |  7       | Labels
✔ |  6       | Leave-one-out CV
✔ | 17       | Monte Carlo CV
✔ |  3       | Naming functions
✔ | 15       | Nested CV [0.1 s]
✔ | 107       | Rolling window resampling [0.1 s]
✔ | 15       | Rset constructor
✔ | 16       | Rsplit constructor
✔ |  5       | Strata constructor
✔ | 55       | Tidy methods [0.1 s]
✔ | 18       | V-fold CV

══ Results ══════════════════════════════════════════════════════════════════════════════════════════
Duration: 1.6 s

OK:       489
Failed:   0
Warnings: 0
Skipped:  0
```
Perhaps some of those deserve better names?

Sorry about all the whitespace changes, but those are enforced by the existing .Rproj file (@topepo do you not use RStudio?).