### PR TITLE
Turn on roxygen2 markdown (it was already being used).

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,7 @@ Authors@R: c(
 Maintainer: Max Kuhn <max@rstudio.com>
 Description: Classes and functions to create and summarize different types of resampling objects (e.g. bootstrap, cross-validation). 
 Imports: dplyr, purrr, tibble, rlang, methods
-Depends:  R (>= 3.1), broom, tidyr
+Depends: R (>= 3.1), broom, tidyr
 Suggests: ggplot2, testthat, rmarkdown, knitr, AmesHousing, recipes (>= 0.1.3.9000)
 URL: https://tidymodels.github.io/rsample
 BugReports: https://github.com/tidymodels/rsample/issues
@@ -16,6 +16,7 @@ License: GPL-2
 Encoding: UTF-8
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 6.0.1
+RoxygenNote: 6.1.0
+Roxygen: list(markdown = TRUE)
 Remotes:
     tidymodels/recipes

--- a/man/apparent.Rd
+++ b/man/apparent.Rd
@@ -12,19 +12,19 @@ apparent(data, ...)
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with a single row and classes `apparent`, 
-  `rset`, `tbl_df`, `tbl`, and `data.frame`. The 
-  results include a column for the data split objects and one column 
-  called `id` that has a character string with the resample identifier.
+An tibble with a single row and classes \code{apparent},
+\code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The
+results include a column for the data split objects and one column
+called \code{id} that has a character string with the resample identifier.
 }
 \description{
 When building a model on a data set and re-predicting the same data, the
-  performance estimate from those predictions is often call the 
-  "apparent" performance of the model. This estimate can be wildly 
-  optimistic. "Apparent sampling" here means that the analysis and 
-  assessment samples are the same. These resamples are sometimes used in 
-  the analysis of bootstrap samples and should otherwise be
-  avoided like ol sushi.
+performance estimate from those predictions is often call the
+"apparent" performance of the model. This estimate can be wildly
+optimistic. "Apparent sampling" here means that the analysis and
+assessment samples are the same. These resamples are sometimes used in
+the analysis of bootstrap samples and should otherwise be
+avoided like ol sushi.
 }
 \examples{
 apparent(mtcars)

--- a/man/as.data.frame.rsplit.Rd
+++ b/man/as.data.frame.rsplit.Rd
@@ -4,7 +4,7 @@
 \alias{as.data.frame.rsplit}
 \alias{analysis}
 \alias{assessment}
-\title{Convert an `rsplit` object to a data frame}
+\title{Convert an \code{rsplit} object to a data frame}
 \usage{
 \method{as.data.frame}{rsplit}(x, row.names = NULL, optional = FALSE,
   data = "analysis", ...)
@@ -14,9 +14,9 @@ analysis(x, ...)
 assessment(x, ...)
 }
 \arguments{
-\item{x}{An `rsplit` object.}
+\item{x}{An \code{rsplit} object.}
 
-\item{row.names}{`NULL` or a character vector giving the row names for the data frame. Missing values are not allowed.}
+\item{row.names}{\code{NULL} or a character vector giving the row names for the data frame. Missing values are not allowed.}
 
 \item{optional}{A logical: should the column names of the data be checked for legality?}
 
@@ -26,9 +26,9 @@ assessment(x, ...)
 }
 \description{
 The analysis or assessment code can be returned as a data
-  frame (as dictated by the `data` argument) using
-  `as.data.frame.rsplit`. `analysis` and
-  `assessment` are shortcuts.
+frame (as dictated by the \code{data} argument) using
+\code{as.data.frame.rsplit}. \code{analysis} and
+\code{assessment} are shortcuts.
 }
 \examples{
 library(dplyr)

--- a/man/attrition.Rd
+++ b/man/attrition.Rd
@@ -15,13 +15,13 @@ Job Attrition
 }
 \details{
 These data are from the IBM Watson Analytics Lab.
- The website describes the data with \dQuote{Uncover the
- factors that lead to employee attrition and explore important
- questions such as \sQuote{show me a breakdown of distance
- from home by job role and attrition} or \sQuote{compare
- average monthly income by education and attrition}. This is a
- fictional data set created by IBM data scientists.}. There
- are 1470 rows.
+The website describes the data with \dQuote{Uncover the
+factors that lead to employee attrition and explore important
+questions such as \sQuote{show me a breakdown of distance
+from home by job role and attrition} or \sQuote{compare
+average monthly income by education and attrition}. This is a
+fictional data set created by IBM data scientists.}. There
+are 1470 rows.
 }
 \examples{
 data(attrition)

--- a/man/bootstraps.Rd
+++ b/man/bootstraps.Rd
@@ -11,22 +11,22 @@ bootstraps(data, times = 25, strata = NULL, apparent = FALSE, ...)
 
 \item{times}{The number of bootstrap samples.}
 
-\item{strata}{A variable that is used to conduct stratified sampling. When not `NULL`, each bootstrap sample is created within the stratification variable.}
+\item{strata}{A variable that is used to conduct stratified sampling. When not \code{NULL}, each bootstrap sample is created within the stratification variable.}
 
-\item{apparent}{A logical. Should an extra resample be added where the analysis and holdout subset are the entire data set. This is required for some estimators used by the `summary` function that require the apparent error rate.}
+\item{apparent}{A logical. Should an extra resample be added where the analysis and holdout subset are the entire data set. This is required for some estimators used by the \code{summary} function that require the apparent error rate.}
 
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with classes `bootstraps`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and a column called `id` that has a character string with the resample identifier.
+An tibble with classes \code{bootstraps}, \code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The results include a column for the data split objects and a column called \code{id} that has a character string with the resample identifier.
 }
 \description{
 A bootstrap sample is a sample that is the same size as the original data set that is made using replacement.  This results in analysis samples that have multiple replicates of some of the original rows of the data. The assessment set is defined as the rows of the original data that were not included in the bootstrap sample. This is often referred to as the "out-of-bag" (OOB) sample.
 }
 \details{
-The argument `apparent` enables the option of an additional "resample" where the analysis and assessment data sets are the same as the original data set. This can be required for some types of analysis of the bootstrap results. 
+The argument \code{apparent} enables the option of an additional "resample" where the analysis and assessment data sets are the same as the original data set. This can be required for some types of analysis of the bootstrap results.
 
-The `strata` argument is based on a similar argument in the random forest package were the bootstrap samples are conducted *within the stratification variable*. The can help ensure that the number of data points in the bootstrap sample is equivalent to the proportions in the original data set.
+The \code{strata} argument is based on a similar argument in the random forest package were the bootstrap samples are conducted \emph{within the stratification variable}. The can help ensure that the number of data points in the bootstrap sample is equivalent to the proportions in the original data set.
 }
 \examples{
 bootstraps(mtcars, times = 2)

--- a/man/complement.Rd
+++ b/man/complement.Rd
@@ -7,7 +7,7 @@
 complement(x, ...)
 }
 \arguments{
-\item{x}{An `rsplit` object}
+\item{x}{An \code{rsplit} object}
 
 \item{...}{Not currently used}
 }
@@ -15,10 +15,10 @@ complement(x, ...)
 A integer vector.
 }
 \description{
-Given an `rsplit` object, `complement` will determine which
-  of the data rows are contained in the assessment set. To save space,
-  many of the `rset` objects will not contain indicies for the
-  assessment split.
+Given an \code{rsplit} object, \code{complement} will determine which
+of the data rows are contained in the assessment set. To save space,
+many of the \code{rset} objects will not contain indicies for the
+assessment split.
 }
 \examples{
 set.seed(28432)
@@ -28,5 +28,5 @@ fold_rs$splits[[1]]$out_id
 complement(fold_rs$splits[[1]])
 }
 \seealso{
-[populate()]
+\code{\link[=populate]{populate()}}
 }

--- a/man/fill.Rd
+++ b/man/fill.Rd
@@ -7,11 +7,11 @@
 fill(x, ...)
 }
 \arguments{
-\item{x}{A `rsplit` and `rset` object.}
+\item{x}{A \code{rsplit} and \code{rset} object.}
 
 \item{...}{Not currently used}
 }
 \description{
-`fill()` has been deprecated and will be removed in version `0.0.4`.
-Please use [populate()] instead.
+\code{fill()} has been deprecated and will be removed in version \code{0.0.4}.
+Please use \code{\link[=populate]{populate()}} instead.
 }

--- a/man/form_pred.Rd
+++ b/man/form_pred.Rd
@@ -7,19 +7,19 @@
 form_pred(object, ...)
 }
 \arguments{
-\item{object}{A model formula or [stats::terms()]
+\item{object}{A model formula or \code{\link[stats:terms]{stats::terms()}}
 object.}
 
-\item{...}{Arguments to pass to [all.vars()]}
+\item{...}{Arguments to pass to \code{\link[=all.vars]{all.vars()}}}
 }
 \value{
 A character vector of names
 }
 \description{
-`all.vars` returns all variables used in a formula. This
- function only returns the variables explicitly used on the
- right-hand side (i.e., it will not resolve dots unless the
- object is terms with a data set specified).
+\code{all.vars} returns all variables used in a formula. This
+function only returns the variables explicitly used on the
+right-hand side (i.e., it will not resolve dots unless the
+object is terms with a data set specified).
 }
 \examples{
 form_pred(y ~ x + z)

--- a/man/gather.rset.Rd
+++ b/man/gather.rset.Rd
@@ -2,40 +2,40 @@
 % Please edit documentation in R/gather.R
 \name{gather.rset}
 \alias{gather.rset}
-\title{Gather an `rset` Object}
+\title{Gather an \code{rset} Object}
 \usage{
-\method{gather}{rset}(data, key = NULL, value = NULL, ..., na.rm = TRUE,
-  convert = FALSE, factor_key = TRUE)
+\method{gather}{rset}(data, key = NULL, value = NULL, ...,
+  na.rm = TRUE, convert = FALSE, factor_key = TRUE)
 }
 \arguments{
-\item{data}{An `rset` object.}
+\item{data}{An \code{rset} object.}
 
 \item{key, value, ...}{Not specified in this method and will be
 ignored. Note that this means that selectors are ignored if
 they are passed to the function.}
 
-\item{na.rm}{If `TRUE`, will remove rows from output where the
-value column in `NA`.}
+\item{na.rm}{If \code{TRUE}, will remove rows from output where the
+value column in \code{NA}.}
 
-\item{convert}{If `TRUE` will automatically run
-`type.convert()` on the key column. This is useful if the column
+\item{convert}{If \code{TRUE} will automatically run
+\code{type.convert()} on the key column. This is useful if the column
 names are actually numeric, integer, or logical.}
 
 \item{factor_key}{If FALSE, the default, the key values will be
-stored as a character vector. If `TRUE`, will be stored as a
+stored as a character vector. If \code{TRUE}, will be stored as a
 factor, which preserves the original ordering of the columns.}
 }
 \value{
 A data frame with the ID columns, a column called
- `model` (with the previous column names), and a column called
- `statistic` (with the values).
+\code{model} (with the previous column names), and a column called
+\code{statistic} (with the values).
 }
 \description{
-This method uses `gather` on an `rset` object to stack all of
- the non-ID or split columns in the data and is useful for
- stacking model evaluation statistics. The resulting data frame
- has a column based on the column names of `data` and another for
- the values.
+This method uses \code{gather} on an \code{rset} object to stack all of
+the non-ID or split columns in the data and is useful for
+stacking model evaluation statistics. The resulting data frame
+has a column based on the column names of \code{data} and another for
+the values.
 }
 \examples{
 library(rsample)

--- a/man/group_vfold_cv.Rd
+++ b/man/group_vfold_cv.Rd
@@ -13,24 +13,24 @@ group_vfold_cv(data, group = NULL, v = NULL, ...)
 data that will be used to create the splits.}
 
 \item{v}{The number of partitions of the data set. If let
-`NULL`, `v` will be set to the number of unique values
+\code{NULL}, \code{v} will be set to the number of unique values
 in the group.}
 
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with classes `group_vfold_cv`,
- `rset`, `tbl_df`, `tbl`, and `data.frame`.
- The results include a column for the data split objects and an
- identification variable.
+An tibble with classes \code{group_vfold_cv},
+\code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}.
+The results include a column for the data split objects and an
+identification variable.
 }
 \description{
 Group V-fold cross-validation creates splits of the data based
- on some grouping variable (which may have more than a single row
- associated with it). The function can create as many splits as
- there are unique values of the grouping variable or it can
- create a smaller set of splits where more than one value is left
- out at a time.
+on some grouping variable (which may have more than a single row
+associated with it). The function can create as many splits as
+there are unique values of the grouping variable or it can
+create a smaller set of splits where more than one value is left
+out at a time.
 }
 \examples{
 set.seed(3527)

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -24,19 +24,19 @@ testing(x)
 
 \item{...}{Not currently used.}
 
-\item{x}{An `rsplit` object produced by `initial_split`}
+\item{x}{An \code{rsplit} object produced by \code{initial_split}}
 }
 \value{
-An `rset` object that can be used with the `training` and `testing` functions to extract the data in each split.
+An \code{rset} object that can be used with the \code{training} and \code{testing} functions to extract the data in each split.
 }
 \description{
-`initial_split` creates a single binary split of the data into a training set
-and testing set. `initial_time_split` does the same, but takes the _first_ `prop`
-samples for training, instead of a a random selection. `training` and
-`testing` are used to extract the resulting data.
+\code{initial_split} creates a single binary split of the data into a training set
+and testing set. \code{initial_time_split} does the same, but takes the \emph{first} \code{prop}
+samples for training, instead of a a random selection. \code{training} and
+\code{testing} are used to extract the resulting data.
 }
 \details{
-The `strata` argument causes the random sampling to be conducted *within the stratification variable*. The can help ensure that the number of data points in the training data is equivalent to the proportions in the original data set.
+The \code{strata} argument causes the random sampling to be conducted \emph{within the stratification variable}. The can help ensure that the number of data points in the training data is equivalent to the proportions in the original data set.
 }
 \examples{
 set.seed(1353)

--- a/man/labels.rset.Rd
+++ b/man/labels.rset.Rd
@@ -10,7 +10,7 @@
 \method{labels}{vfold_cv}(object, make_factor = FALSE, ...)
 }
 \arguments{
-\item{object}{An `rset` object}
+\item{object}{An \code{rset} object}
 
 \item{make_factor}{A logical for whether the results should be
 character or a factor.}
@@ -22,8 +22,8 @@ A single character or factor vector.
 }
 \description{
 Produce a vector of resampling labels (e.g. "Fold1") from
- an `rset` object. Currently, `nested_cv`
- is not supported.
+an \code{rset} object. Currently, \code{nested_cv}
+is not supported.
 }
 \examples{
 labels(vfold_cv(mtcars))

--- a/man/labels.rsplit.Rd
+++ b/man/labels.rsplit.Rd
@@ -7,7 +7,7 @@
 \method{labels}{rsplit}(object, ...)
 }
 \arguments{
-\item{object}{An `rsplit` object}
+\item{object}{An \code{rsplit} object}
 
 \item{...}{Not currently used.}
 }
@@ -15,8 +15,8 @@
 A tibble.
 }
 \description{
-Produce a tibble of identification variables so that single 
- splits can be linked to a particular resample.
+Produce a tibble of identification variables so that single
+splits can be linked to a particular resample.
 }
 \examples{
 cv_splits <- vfold_cv(mtcars)

--- a/man/loo_cv.Rd
+++ b/man/loo_cv.Rd
@@ -12,7 +12,7 @@ loo_cv(data, ...)
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with classes `loo_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and one column called `id` that has a character string with the resample identifier.
+An tibble with classes \code{loo_cv}, \code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The results include a column for the data split objects and one column called \code{id} that has a character string with the resample identifier.
 }
 \description{
 Leave-one-out (LOO) cross-validation uses one data point in the original set as the assessment data and all other data points as the analysis set. A LOO resampling set has as many resamples as rows in the original data set.

--- a/man/make_strata.Rd
+++ b/man/make_strata.Rd
@@ -9,40 +9,40 @@ make_strata(x, nunique = 5, pool = 0.15, depth = 20)
 \arguments{
 \item{x}{An input vector.}
 
-\item{nunique}{An integer for the number of unique value threshold in the 
+\item{nunique}{An integer for the number of unique value threshold in the
 algorithm.}
 
 \item{pool}{A proportion of data used to determine if a particular group is
 too small and should be pooled into another group.}
 
-\item{depth}{An integer that is used to determine the best number of 
-percentiles that should be used. The number of bins are based on 
-`min(5, floor(n / depth))` where `n = length(x)`. 
-If `x` is numeric, there must be at least 40 rows in the data set 
-(when `depth = 20`) to conduct stratified sampling.}
+\item{depth}{An integer that is used to determine the best number of
+percentiles that should be used. The number of bins are based on
+\code{min(5, floor(n / depth))} where \code{n = length(x)}.
+If \code{x} is numeric, there must be at least 40 rows in the data set
+(when \code{depth = 20}) to conduct stratified sampling.}
 }
 \value{
 A factor vector.
 }
 \description{
 For stratified resampling, this function can create strata from numeric data
-  and also make non-numeric data more conducive to be used for 
-  stratification.
+and also make non-numeric data more conducive to be used for
+stratification.
 }
 \details{
-For numeric data, if the number of unique levels is less than 
-`nunique`, the data are treated as categorical data. 
+For numeric data, if the number of unique levels is less than
+\code{nunique}, the data are treated as categorical data.
 
-For categorical inputs, the function will find levels of `x` than
-  occur in the data with percentage less than `pool`. The values from
-  these groups will be randomly assigned to the remaining strata (as will
-  data points that have missing values in `x`). 
-  
-For numeric data with more unique values than `nunique`, the data
-  will be converted to being categorical based on percentiles of the data. 
-  The percentile groups will have no more than 20 percent of the data in 
-  each group. Again, missing values in `x` are randomly assigned
-  to groups.
+For categorical inputs, the function will find levels of \code{x} than
+occur in the data with percentage less than \code{pool}. The values from
+these groups will be randomly assigned to the remaining strata (as will
+data points that have missing values in \code{x}).
+
+For numeric data with more unique values than \code{nunique}, the data
+will be converted to being categorical based on percentiles of the data.
+The percentile groups will have no more than 20 percent of the data in
+each group. Again, missing values in \code{x} are randomly assigned
+to groups.
 }
 \examples{
 set.seed(61)

--- a/man/mc_cv.Rd
+++ b/man/mc_cv.Rd
@@ -18,13 +18,13 @@ mc_cv(data, prop = 3/4, times = 25, strata = NULL, ...)
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with classes `mc_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and a column called `id` that has a character string with the resample identifier.
+An tibble with classes \code{mc_cv}, \code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The results include a column for the data split objects and a column called \code{id} that has a character string with the resample identifier.
 }
 \description{
 One resample of Monte Carlo cross-validation takes a random sample (without replacement) of the original data set to be used for analysis. All other data points are added to the assessment set.
 }
 \details{
-The `strata` argument causes the random sampling to be conducted *within the stratification variable*. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.
+The \code{strata} argument causes the random sampling to be conducted \emph{within the stratification variable}. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.
 }
 \examples{
 mc_cv(mtcars, times = 2)

--- a/man/nested_cv.Rd
+++ b/man/nested_cv.Rd
@@ -11,27 +11,27 @@ nested_cv(data, outside, inside)
 
 \item{outside}{The initial resampling specification. This can be an already
 created object or an expression of a new object (see the examples below).
-If the latter is used, the `data` argument does not need to be
+If the latter is used, the \code{data} argument does not need to be
 specified and, if it is given, will be ignored.}
 
 \item{inside}{An expression for the type of resampling to be conducted
 within the initial procedure.}
 }
 \value{
-An tibble with classe `nested_cv` and any other classes that
-  outer resampling process normally contains. The results include a
- column for the outer data split objects, one or more `id` columns,
- and a column of nested tibbles called `inner_resamples` with the
- additional resamples.
+An tibble with classe \code{nested_cv} and any other classes that
+outer resampling process normally contains. The results include a
+column for the outer data split objects, one or more \code{id} columns,
+and a column of nested tibbles called \code{inner_resamples} with the
+additional resamples.
 }
 \description{
-`nested_cv` can be used to take the results of one resampling procedure
-  and conduct further resamples within each split. Any type of resampling
-  used in `rsample` can be used.
+\code{nested_cv} can be used to take the results of one resampling procedure
+and conduct further resamples within each split. Any type of resampling
+used in \code{rsample} can be used.
 }
 \details{
 It is a bad idea to use bootstrapping as the outer resampling procedure (see
-  the example below)
+the example below)
 }
 \examples{
 ## Using expressions for the resampling procedures:

--- a/man/populate.Rd
+++ b/man/populate.Rd
@@ -7,7 +7,7 @@
 populate(x, ...)
 }
 \arguments{
-\item{x}{A `rsplit` and `rset` object.}
+\item{x}{A \code{rsplit} and \code{rset} object.}
 
 \item{...}{Not currently used}
 }
@@ -15,9 +15,9 @@ populate(x, ...)
 An object of the same kind with the integer indicies.
 }
 \description{
-Many `rsplit` and `rset` objects do not contain indicators for
-  the assessment samples. `populate()` can be used to fill the slot
-  for the appropriate indices.
+Many \code{rsplit} and \code{rset} objects do not contain indicators for
+the assessment samples. \code{populate()} can be used to fill the slot
+for the appropriate indices.
 }
 \examples{
 set.seed(28432)

--- a/man/pretty.vfold_cv.Rd
+++ b/man/pretty.vfold_cv.Rd
@@ -28,7 +28,7 @@
 \method{pretty}{group_vfold_cv}(x, ...)
 }
 \arguments{
-\item{x}{An `rset` object}
+\item{x}{An \code{rset} object}
 
 \item{...}{Not currently used.}
 }

--- a/man/rolling_origin.Rd
+++ b/man/rolling_origin.Rd
@@ -14,21 +14,21 @@ rolling_origin(data, initial = 5, assess = 1, cumulative = TRUE,
 
 \item{assess}{The number of samples used for each assessment resample.}
 
-\item{cumulative}{A logical. Should the analysis resample grow beyond the size specified by `initial` at each resample?.}
+\item{cumulative}{A logical. Should the analysis resample grow beyond the size specified by \code{initial} at each resample?.}
 
 \item{skip}{A integer indicating how many (if any) resamples to skip to thin the total amount of data points in the analysis resample.}
 
 \item{...}{Not currently used.}
 }
 \value{
-An tibble with classes `rolling_origin`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and a column called `id` that has a character string with the resample identifier.
+An tibble with classes \code{rolling_origin}, \code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The results include a column for the data split objects and a column called \code{id} that has a character string with the resample identifier.
 }
 \description{
 This resampling method is useful when the data set has a strong time component. The resamples are not random and contain data points that are consecutive values. The function assumes that the original data set are sorted in time order.
 }
 \details{
-The main options, `initial` and `assess`, control the number of data points from the original data that are in the analysis and assessment set, respectively. When `cumulative = TRUE`, the analysis set will grow as resampling continues while the assessment set size will always remain static.
-`skip` enables the function to not use every data point in the resamples. When `skip = 0`, the resampling data sets will increment by one position. Suppose that the rows of a data set are consecutive days. Using `skip = 6` will make the analysis data set operate on *weeks* instead of days. The assessment set size is not affected by this option.
+The main options, \code{initial} and \code{assess}, control the number of data points from the original data that are in the analysis and assessment set, respectively. When \code{cumulative = TRUE}, the analysis set will grow as resampling continues while the assessment set size will always remain static.
+\code{skip} enables the function to not use every data point in the resamples. When \code{skip = 0}, the resampling data sets will increment by one position. Suppose that the rows of a data set are consecutive days. Using \code{skip = 6} will make the analysis data set operate on \emph{weeks} instead of days. The assessment set size is not affected by this option.
 }
 \examples{
 set.seed(1131)

--- a/man/rsample.Rd
+++ b/man/rsample.Rd
@@ -7,36 +7,36 @@
 \title{rsample: General Resampling Infrastructure for R}
 \description{
 \pkg{rsample} has functions to create variations of a data set
- that can be used to evaluate models or to estimate the
- sampling distribution of some statistic.
+that can be used to evaluate models or to estimate the
+sampling distribution of some statistic.
 }
 \section{Terminology}{
 
 \itemize{
- \item A **resample** is the result of a two-way split of a
- data set. For example, when bootstrapping, one part of the
- resample is a sample with replacement of the original data.
- The other part of the split contains the instances that were
- not contained in the bootstrap sample. The data structure
- `rsplit` is used to store a single resample. 
- \item When the data are split in two, the portion that are
- used to estimate the model or calculate the statistic is
- called the **analysis** set here. In machine learning this
- is sometimes called the "training set" but this would be
- poorly named since it might conflict with any initial split
- of the original data.
- \item Conversely, the other data in the split are called the
-    **assessment** data. In bootstrapping, these data are
-    often called the "out-of-bag" samples. 
- \item A collection of resamples is contained in an 
- `rset` object.
+\item A \strong{resample} is the result of a two-way split of a
+data set. For example, when bootstrapping, one part of the
+resample is a sample with replacement of the original data.
+The other part of the split contains the instances that were
+not contained in the bootstrap sample. The data structure
+\code{rsplit} is used to store a single resample.
+\item When the data are split in two, the portion that are
+used to estimate the model or calculate the statistic is
+called the \strong{analysis} set here. In machine learning this
+is sometimes called the "training set" but this would be
+poorly named since it might conflict with any initial split
+of the original data.
+\item Conversely, the other data in the split are called the
+\strong{assessment} data. In bootstrapping, these data are
+often called the "out-of-bag" samples.
+\item A collection of resamples is contained in an
+\code{rset} object.
 }
 }
 
 \section{Basic Functions}{
 
-The main resampling functions are: [vfold_cv()], 
-  [bootstraps()], [mc_cv()], 
-  [rolling_origin()], and [nested_cv()].
+The main resampling functions are: \code{\link[=vfold_cv]{vfold_cv()}},
+\code{\link[=bootstraps]{bootstraps()}}, \code{\link[=mc_cv]{mc_cv()}},
+\code{\link[=rolling_origin]{rolling_origin()}}, and \code{\link[=nested_cv]{nested_cv()}}.
 }
 

--- a/man/rsample2caret.Rd
+++ b/man/rsample2caret.Rd
@@ -10,24 +10,24 @@ rsample2caret(object, data = c("analysis", "assessment"))
 caret2rsample(ctrl, data = NULL)
 }
 \arguments{
-\item{object}{An `rset` object. Currently,
-`nested_cv` is not supported.}
+\item{object}{An \code{rset} object. Currently,
+\code{nested_cv} is not supported.}
 
 \item{data}{The data that was originally used to produce the
-`ctrl` object.}
+\code{ctrl} object.}
 
-\item{ctrl}{An object produced by `trainControl` that has
-had the `index` and `indexOut` elements populated by
+\item{ctrl}{An object produced by \code{trainControl} that has
+had the \code{index} and \code{indexOut} elements populated by
 integers. One method of getting this is to extract the
-`control` objects from an object produced by `train`.}
+\code{control} objects from an object produced by \code{train}.}
 }
 \value{
-`rsample2caret` returns a list that mimics the
- `index` and `indexOut` elements of a
- `trainControl` object. `caret2rsample` returns an
- `rset` object of the appropriate class.
+\code{rsample2caret} returns a list that mimics the
+\code{index} and \code{indexOut} elements of a
+\code{trainControl} object. \code{caret2rsample} returns an
+\code{rset} object of the appropriate class.
 }
 \description{
 These functions can convert resampling objects between
- \pkg{rsample} and \pkg{caret}.
+\pkg{rsample} and \pkg{caret}.
 }

--- a/man/tidy.rsplit.Rd
+++ b/man/tidy.rsplit.Rd
@@ -16,22 +16,22 @@
 \method{tidy}{nested_cv}(x, ...)
 }
 \arguments{
-\item{x}{A  `rset` or  `rsplit` object}
+\item{x}{A  \code{rset} or  \code{rsplit} object}
 
-\item{unique_ind}{Should unique row identifiers be returned? For example, if  `FALSE` then bootstrapping results will include multiple rows in the sample for the same row in the original data.}
+\item{unique_ind}{Should unique row identifiers be returned? For example, if  \code{FALSE} then bootstrapping results will include multiple rows in the sample for the same row in the original data.}
 
 \item{...}{Not currently used.}
 }
 \value{
-A tibble with columns  `Row` and  `Data`. The latter has possible values "Analysis" or "Assessment". For  `rset` inputs, identification columns are also returned but their names and values depend on the type of resampling.  `vfold_cv` contains a column "Fold" and, if repeats are used, another called "Repeats".  `bootstraps` and  `mc_cv` use the column "Resample".
+A tibble with columns  \code{Row} and  \code{Data}. The latter has possible values "Analysis" or "Assessment". For  \code{rset} inputs, identification columns are also returned but their names and values depend on the type of resampling.  \code{vfold_cv} contains a column "Fold" and, if repeats are used, another called "Repeats".  \code{bootstraps} and  \code{mc_cv} use the column "Resample".
 }
 \description{
-The `tidy` function from the  \pkg{broom} package can be used on  `rset` and  `rsplit` objects to generate tibbles with which rows are in the analysis and assessment sets.
+The \code{tidy} function from the  \pkg{broom} package can be used on  \code{rset} and  \code{rsplit} objects to generate tibbles with which rows are in the analysis and assessment sets.
 }
 \details{
-Note that for nested resampling, the rows of the inner resample, 
-  named `inner_Row`, are *relative* row indices and do not
-  correspond to the rows in the original data set.
+Note that for nested resampling, the rows of the inner resample,
+named \code{inner_Row}, are \emph{relative} row indices and do not
+correspond to the rows in the original data set.
 }
 \examples{
 library(ggplot2)

--- a/man/two_class_dat.Rd
+++ b/man/two_class_dat.Rd
@@ -11,8 +11,8 @@
 Two Class Data
 }
 \details{
-There are artifical data with two predictors (`A` and `B`) and
- a factor outcome variable (`Class`).
+There are artifical data with two predictors (\code{A} and \code{B}) and
+a factor outcome variable (\code{Class}).
 }
 \examples{
 data(two_class_dat)

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -18,15 +18,15 @@ vfold_cv(data, v = 10, repeats = 1, strata = NULL, ...)
 \item{...}{Not currently used.}
 }
 \value{
-A tibble with classes `vfold_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and one or more identification variables. For a single repeats, there will be one column called `id` that has a character string with the fold identifier. For repeats, `id` is the repeat number and an additional column called `id2` that contains the fold information (within repeat).
+A tibble with classes \code{vfold_cv}, \code{rset}, \code{tbl_df}, \code{tbl}, and \code{data.frame}. The results include a column for the data split objects and one or more identification variables. For a single repeats, there will be one column called \code{id} that has a character string with the fold identifier. For repeats, \code{id} is the repeat number and an additional column called \code{id2} that contains the fold information (within repeat).
 }
 \description{
 V-fold cross-validation randomly splits the data into V groups of roughly equal size (called "folds"). A resample of the analysis data consisted of V-1 of the folds while the assessment set contains the final fold. In basic V-fold cross-validation (i.e. no repeats), the number of resamples is equal to V.
 }
 \details{
-The `strata` argument causes the random sampling to be conducted *within the stratification variable*. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.  
+The \code{strata} argument causes the random sampling to be conducted \emph{within the stratification variable}. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.
 
-When more than one repeat is requested, the basic V-fold cross-validation is conducted each time. For example, if three repeats are used with `v = 10`, there are a total of 30 splits which as three groups of 10 that are generated separately.
+When more than one repeat is requested, the basic V-fold cross-validation is conducted each time. For example, if three repeats are used with \code{v = 10}, there are a total of 30 splits which as three groups of 10 that are generated separately.
 }
 \examples{
 vfold_cv(mtcars, v = 10)


### PR DESCRIPTION
Seems like `Roxygen: list(markdown = TRUE)` had been forgotten. This turns it on and redocuments. It also bumps the roxygen2 version to 6.1.0