### PR TITLE
Correct spelling

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -51,7 +51,7 @@ NULL
 #' @docType data
 #' @return \item{drinks}{a data frame}
 #'
-#' @source The Federal Reserve Back of St. Louis website https://fred.stlouisfed.org/series/S4248SM144NCEN
+#' @source The Federal Reserve Bank of St. Louis website https://fred.stlouisfed.org/series/S4248SM144NCEN
 #'
 #' @keywords datasets
 #' @examples

--- a/vignettes/Applications/Time_Series.Rmd
+++ b/vignettes/Applications/Time_Series.Rmd
@@ -23,7 +23,7 @@ library(zoo)
 
 "[Demo Week: Tidy Forecasting with `sweep`](http://www.business-science.io/code-tools/2017/10/25/demo_week_sweep.html)" is an excellent article that uses tidy methods with time series. This article uses their analysis with `rsample` to get performance estimates for future observations using [rolling forecast origin resampling](https://robjhyndman.com/hyndsight/crossvalidation/). 
 
-The data are sales of alcoholic beverages originally from [the Federal Reserve Back of St. Louis website](https://fred.stlouisfed.org/series/S4248SM144NCEN).
+The data are sales of alcoholic beverages originally from [the Federal Reserve Bank of St. Louis website](https://fred.stlouisfed.org/series/S4248SM144NCEN).
 
 ```{r read-data}
 library(tidymodels)


### PR DESCRIPTION
Corrected text "Federal Reserve Back of St. Louis" to "Federal Reserve Bank of St. Louis" in R/data.R and Time_Series.Rmd vignette.