### PR TITLE
correctly count n for vectors

### DIFF
--- a/R/rolling_origin.R
+++ b/R/rolling_origin.R
@@ -37,7 +37,11 @@
 #' @export
 rolling_origin <- function(data, initial = 5, assess = 1,
                            cumulative = TRUE, skip = 0, ...) {
-  n <- nrow(data)
+  if(is.vector(data)) {
+    n <- NROW(data) # lowercase `nrow()` will not work for vectors
+  } else {
+    n <- nrow(data)
+  }
 
   if (n < initial + assess)
     stop("There should be at least ",


### PR DESCRIPTION
when supplying a vector (e.g. `c(1,2,3,4)`), usually the following error gets thrown:

`There should be at least ",
         initial + assess,
         " nrows in `data`"`

this because `nrow()` instead of `NROW()` is used. The former does not support atomic vectors.