### PR TITLE
Don't need rsample::: in tests

### DIFF
--- a/tests/testthat/test_boot.R
+++ b/tests/testthat/test_boot.R
@@ -9,7 +9,7 @@ dat1 <- data.frame(a = 1:20, b = letters[1:20])
 test_that('default param', {
   set.seed(11)
   rs1 <- bootstraps(dat1)
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis == nrow(dat1)))
   same_data <-
@@ -26,7 +26,7 @@ test_that('default param', {
 
 test_that('apparent', {
   rs2 <- bootstraps(dat1, apparent = TRUE)
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
 
   expect_true(all(sizes2$analysis == nrow(dat1)))
   expect_true(all(sizes2$assessment[nrow(sizes2)] == nrow(dat1)))
@@ -41,7 +41,7 @@ test_that('strata', {
   iris2 <- iris[1:130, ]
   set.seed(11)
   rs4 <- bootstraps(iris2,  strata = "Species")
-  sizes4 <- rsample:::dim_rset(rs4)
+  sizes4 <- dim_rset(rs4)
 
   expect_true(all(sizes4$analysis == nrow(iris2)))
 
@@ -59,7 +59,7 @@ test_that('strata', {
   expect_true(all(good_holdout))
 
   rs5 <- bootstraps(iris2, apparent = TRUE, strata = "Species")
-  sizes5 <- rsample:::dim_rset(rs5)
+  sizes5 <- dim_rset(rs5)
 
   expect_true(all(sizes5$analysis == nrow(iris2)))
   expect_true(all(sizes5$assessment[nrow(sizes5)] == nrow(iris2)))

--- a/tests/testthat/test_dplyr.R
+++ b/tests/testthat/test_dplyr.R
@@ -22,35 +22,35 @@ check_att <- function(x, y)
 ###################################################################
 
 test_that('object types', {
-  expect_true(rsample:::is_rset(obj_1))
-  expect_false(rsample:::is_rset(obj_1[, -1]))
+  expect_true(is_rset(obj_1))
+  expect_false(is_rset(obj_1[, -1]))
 })
 
 ###################################################################
 
 test_that('dplyr ops', {
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_2 %>% filter(id == "Bootstrap02")
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_3 %>% mutate(blah = substr(id, 1, 3))
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_4 %>% select(splits, id)
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_1 %>% arrange(id)
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_1 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -61,7 +61,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_2 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -72,7 +72,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_3 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -83,7 +83,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_4 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -94,7 +94,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_5 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -105,7 +105,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_6 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -116,7 +116,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_7 %>% mutate(blah = substr(id, 1, 3)) %>% rename(newer = blah)
     )
   )
@@ -127,7 +127,7 @@ test_that('dplyr ops', {
     )
   )
   expect_true(
-    rsample:::is_rset(
+    is_rset(
       obj_3 %>% slice(1L)
     )
   )

--- a/tests/testthat/test_group.R
+++ b/tests/testthat/test_group.R
@@ -5,7 +5,7 @@ library(rsample)
 library(purrr)
 library(tibble)
 
-iris2 <- as.tibble(iris)
+iris2 <- as_tibble(iris)
 
 get_id_left_out <- function(x)
      unique(as.character(assessment(x)$Species))
@@ -22,7 +22,7 @@ test_that('bad args', {
 test_that('default param', {
   set.seed(11)
   rs1 <- group_vfold_cv(iris, "Species")
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis == 100))
   expect_true(all(sizes1$assessment == 50))
@@ -45,7 +45,7 @@ test_that('default param', {
 test_that('v < max v', {
   set.seed(11)
   rs2 <- group_vfold_cv(iris, "Species", v = 2)
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
 
   expect_true(!all(sizes2$analysis == 100))
   expect_true(!all(sizes2$assessment == 50))
@@ -67,7 +67,7 @@ test_that('v < max v', {
 test_that('tibble input', {
   set.seed(11)
   rs3 <- group_vfold_cv(iris2, "Species")
-  sizes3 <- rsample:::dim_rset(rs3)
+  sizes3 <- dim_rset(rs3)
 
   expect_true(all(sizes3$analysis == 100))
   expect_true(all(sizes3$assessment == 50))

--- a/tests/testthat/test_mc.R
+++ b/tests/testthat/test_mc.R
@@ -9,7 +9,7 @@ dat1 <- data.frame(a = 1:20, b = letters[1:20])
 test_that('default param', {
   set.seed(11)
   rs1 <- mc_cv(dat1)
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis == 15))
   expect_true(all(sizes1$assessment == 5))
@@ -28,7 +28,7 @@ test_that('default param', {
 test_that('different percent', {
   set.seed(11)
   rs2 <- mc_cv(dat1, prop = .5)
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
 
   expect_true(all(sizes2$analysis == 10))
   expect_true(all(sizes2$assessment == 10))
@@ -48,7 +48,7 @@ test_that('strata', {
   iris2 <- iris[1:130, ]
   set.seed(11)
   rs3 <- mc_cv(iris2, strata = "Species")
-  sizes3 <- rsample:::dim_rset(rs3)
+  sizes3 <- dim_rset(rs3)
 
   expect_true(all(sizes3$analysis == 99))
   expect_true(all(sizes3$assessment == 31))

--- a/tests/testthat/test_names.R
+++ b/tests/testthat/test_names.R
@@ -4,9 +4,9 @@ library(testthat)
 library(rsample)
 
 test_that('basic naming sequences', {
-  expect_equal(rsample:::names0(2), c("x1", "x2"))
-  expect_equal(rsample:::names0(2, "y"), c("y1", "y2"))
-  expect_equal(rsample:::names0(10),
+  expect_equal(names0(2), c("x1", "x2"))
+  expect_equal(names0(2, "y"), c("y1", "y2"))
+  expect_equal(names0(10),
                c(paste0("x0", 1:9), "x10"))
 })
 

--- a/tests/testthat/test_nesting.R
+++ b/tests/testthat/test_nesting.R
@@ -9,10 +9,10 @@ test_that('default param', {
   rs1 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),
                    inside = vfold_cv(v = 3))
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
   expect_true(all(sizes1$analysis == 27))
   expect_true(all(sizes1$assessment == 3))
-  subsizes1 <- map(rs1$inner_resamples, rsample:::dim_rset)
+  subsizes1 <- map(rs1$inner_resamples, dim_rset)
   subsizes1 <- do.call("rbind", subsizes1)
   expect_true(all(subsizes1$analysis == 18))
   expect_true(all(subsizes1$assessment == 9))
@@ -21,10 +21,10 @@ test_that('default param', {
   rs2 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),
                    inside = bootstraps(times = 3))
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
   expect_true(all(sizes2$analysis == 27))
   expect_true(all(sizes2$assessment == 3))
-  subsizes2 <- map(rs2$inner_resamples, rsample:::dim_rset)
+  subsizes2 <- map(rs2$inner_resamples, dim_rset)
   subsizes2 <- do.call("rbind", subsizes2)
   expect_true(all(subsizes2$analysis == 27))
 
@@ -32,10 +32,10 @@ test_that('default param', {
   rs3 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),
                    inside = mc_cv(prop = 2/3, times = 3))
-  sizes3 <- rsample:::dim_rset(rs3)
+  sizes3 <- dim_rset(rs3)
   expect_true(all(sizes3$analysis == 27))
   expect_true(all(sizes3$assessment == 3))
-  subsizes3 <- map(rs3$inner_resamples, rsample:::dim_rset)
+  subsizes3 <- map(rs3$inner_resamples, dim_rset)
   subsizes3 <- do.call("rbind", subsizes3)
   expect_true(all(subsizes3$analysis == 18))
   expect_true(all(subsizes3$assessment == 9))

--- a/tests/testthat/test_rolling.R
+++ b/tests/testthat/test_rolling.R
@@ -8,7 +8,7 @@ dat1 <- data.frame(a = 1:20, b = letters[1:20])
 
 test_that('default param', {
   rs1 <- rolling_origin(dat1)
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$assessment == 1))
   expect_true(all(sizes1$analysis == 5:19))
@@ -28,7 +28,7 @@ test_that('default param', {
 
 test_that('larger holdout', {
   rs2 <- rolling_origin(dat1, assess = 3)
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
 
   expect_true(all(sizes2$assessment == 3))
   expect_true(all(sizes2$analysis == 5:17))
@@ -45,7 +45,7 @@ test_that('larger holdout', {
 
 test_that('fixed analysis size', {
   rs3 <- rolling_origin(dat1, cumulative = FALSE)
-  sizes3 <- rsample:::dim_rset(rs3)
+  sizes3 <- dim_rset(rs3)
 
   expect_true(all(sizes3$assessment == 1))
   expect_true(all(sizes3$analysis == 5))
@@ -62,7 +62,7 @@ test_that('fixed analysis size', {
 
 test_that('skipping', {
   rs4 <- rolling_origin(dat1, cumulative = FALSE, skip = 2)
-  sizes4 <- rsample:::dim_rset(rs4)
+  sizes4 <- dim_rset(rs4)
 
   expect_true(all(sizes4$assessment == 1))
   expect_true(all(sizes4$analysis == 5))

--- a/tests/testthat/test_rset.R
+++ b/tests/testthat/test_rset.R
@@ -7,17 +7,17 @@ cars_10fold <- vfold_cv(mtcars)
 
 test_that('bad args', {
   expect_error(
-    rsample:::new_rset(cars_10fold$splits[1:2], cars_10fold$id)
+    new_rset(cars_10fold$splits[1:2], cars_10fold$id)
   )
   expect_error(
-    rsample:::new_rset(cars_10fold$splits, cars_10fold[ "splits"])
+    new_rset(cars_10fold$splits, cars_10fold[ "splits"])
   )
   expect_error(
-    rsample:::new_rset(cars_10fold$splits, cars_10fold$splits)
+    new_rset(cars_10fold$splits, cars_10fold$splits)
   )
   args <- list(a = 1, b = 2, 3)
   expect_error(
-    rsample:::new_rset(
+    new_rset(
       cars_10fold$splits,
       cars_10fold$id,
       attrib = args
@@ -26,7 +26,7 @@ test_that('bad args', {
 })
 
 test_that('simple rset', {
-  res1 <- rsample:::new_rset(
+  res1 <- new_rset(
     cars_10fold$splits,
     cars_10fold$id
   )
@@ -35,7 +35,7 @@ test_that('simple rset', {
   expect_equal(sort(names(attributes(res1))),
                c("class", "names", "row.names"))
 
-  res2 <- rsample:::new_rset(
+  res2 <- new_rset(
     cars_10fold[, "splits"],
     cars_10fold[, "id"]
   )
@@ -47,7 +47,7 @@ test_that('simple rset', {
 
 test_that('rset with attributes', {
   args <- list(value = "potato")
-  res3 <- rsample:::new_rset(
+  res3 <- new_rset(
     cars_10fold$splits,
     cars_10fold$id,
     attrib = args
@@ -58,7 +58,7 @@ test_that('rset with attributes', {
 })
 
 test_that('rset with additional classes', {
-  res4 <- rsample:::new_rset(
+  res4 <- new_rset(
     cars_10fold$splits,
     cars_10fold$id,
     subclass = "potato"

--- a/tests/testthat/test_rsplit.R
+++ b/tests/testthat/test_rsplit.R
@@ -9,34 +9,34 @@ size1 <- object.size(dat1)
 dat2 <- as.matrix(dat1)
 
 test_that('simple rsplit', {
-  rs1 <- rsample:::rsplit(dat1, 1:2, 4:5)
+  rs1 <- rsplit(dat1, 1:2, 4:5)
   expect_equal(rs1$data, dat1)
   expect_equal(rs1$in_id, 1:2)
   expect_equal(rs1$out_id, 4:5)
 })
 
 test_that('simple rsplit with matrices', {
-  rs2 <- rsample:::rsplit(dat2, 1:2, 4:5)
+  rs2 <- rsplit(dat2, 1:2, 4:5)
   expect_equal(rs2$data, dat2)
   expect_equal(rs2$in_id, 1:2)
   expect_equal(rs2$out_id, 4:5)
 })
 
 test_that('bad inputs', {
-  expect_error(rsample:::rsplit(as.list(dat1), 1:2, 4:5))
-  expect_error(rsample:::rsplit(dat1, letters[1:2], 4:5))
-  expect_error(rsample:::rsplit(as.list(dat1), 1:2, letters[4:5]))
-  expect_error(rsample:::rsplit(as.list(dat1), -1:2, 4:5))
-  expect_error(rsample:::rsplit(as.list(dat1), 1:2, -4:5))
-  expect_error(rsample:::rsplit(as.list(dat1), integer(0), 4:5))
+  expect_error(rsplit(as.list(dat1), 1:2, 4:5))
+  expect_error(rsplit(dat1, letters[1:2], 4:5))
+  expect_error(rsplit(as.list(dat1), 1:2, letters[4:5]))
+  expect_error(rsplit(as.list(dat1), -1:2, 4:5))
+  expect_error(rsplit(as.list(dat1), 1:2, -4:5))
+  expect_error(rsplit(as.list(dat1), integer(0), 4:5))
 })
 
 test_that('as.data.frame', {
-  rs3 <- rsample:::rsplit(dat1, 1:2, 4:5)
+  rs3 <- rsplit(dat1, 1:2, 4:5)
   expect_equal(as.data.frame(rs3), dat1[1:2,])
   expect_equal(as.data.frame(rs3, data = "assessment"), dat1[4:5,])
 
-  rs4 <- rsample:::rsplit(dat1, rep(1:2, each = 3), rep(4:5, c(2, 1)))
+  rs4 <- rsplit(dat1, rep(1:2, each = 3), rep(4:5, c(2, 1)))
   expect_equal(as.data.frame(rs4), dat1[c(1, 1, 1, 2, 2, 2),])
   expect_equal(as.data.frame(rs4, data = "assessment"), dat1[c(4, 4, 5),])
 })

--- a/tests/testthat/test_tidy.R
+++ b/tests/testthat/test_tidy.R
@@ -19,7 +19,7 @@ test_that('simple boot', {
   rs1 <- bootstraps(dat1)
   td1 <- tidy(rs1, unique_ind = FALSE)
 
-  name_vals <- rsample:::names0(nrow(rs1), "Bootstrap")
+  name_vals <- names0(nrow(rs1), "Bootstrap")
   for(i in 1:nrow(rs1)) {
     expect_true(
       check_ind(rs1$splits[[i]],

--- a/tests/testthat/test_vfold.R
+++ b/tests/testthat/test_vfold.R
@@ -9,7 +9,7 @@ dat1 <- data.frame(a = 1:20, b = letters[1:20])
 test_that('default param', {
   set.seed(11)
   rs1 <- vfold_cv(dat1)
-  sizes1 <- rsample:::dim_rset(rs1)
+  sizes1 <- dim_rset(rs1)
 
   expect_true(all(sizes1$analysis == 18))
   expect_true(all(sizes1$assessment == 2))
@@ -28,7 +28,7 @@ test_that('default param', {
 test_that('repeated', {
   set.seed(11)
   rs2 <- vfold_cv(dat1, repeats = 4)
-  sizes2 <- rsample:::dim_rset(rs2)
+  sizes2 <- dim_rset(rs2)
 
   expect_true(all(sizes2$analysis == 18))
   expect_true(all(sizes2$assessment == 2))
@@ -48,7 +48,7 @@ test_that('strata', {
   iris2 <- iris[1:130, ]
   set.seed(11)
   rs3 <- vfold_cv(iris2, repeats = 2, strata = "Species")
-  sizes3 <- rsample:::dim_rset(rs3)
+  sizes3 <- dim_rset(rs3)
 
   expect_true(all(sizes3$analysis == 117))
   expect_true(all(sizes3$assessment == 13))


### PR DESCRIPTION
because all internal functions are available in the environment in which the tests are run.

Also changes one instance of `as.tibble()` to `as_tibble()`.