### PR TITLE
Stratification var

### DIFF
--- a/R/boot.R
+++ b/R/boot.R
@@ -1,25 +1,25 @@
 #' Bootstrap Sampling
 #'
-#' A bootstrap sample is a sample that is the same size as the original data set that is made using replacement.  This results in analysis samples that have multiple replicates of some of the original rows of the data. The assessment set is defined as the rows of the original data that were not included in the bootstrap sample. This is often referred to as the "out-of-bag" (OOB) sample. 
+#' A bootstrap sample is a sample that is the same size as the original data set that is made using replacement.  This results in analysis samples that have multiple replicates of some of the original rows of the data. The assessment set is defined as the rows of the original data that were not included in the bootstrap sample. This is often referred to as the "out-of-bag" (OOB) sample.
 
 #' @details
-#' The argument `apparent` enables the option of an additional "resample" where the analysis and assessment data sets are the same as the original data set. This can be required for some types of analysis of the bootstrap results. 
-#' 
+#' The argument `apparent` enables the option of an additional "resample" where the analysis and assessment data sets are the same as the original data set. This can be required for some types of analysis of the bootstrap results.
+#'
 #' The `strata` argument is based on a similar argument in the random forest package were the bootstrap samples are conducted *within the stratification variable*. The can help ensure that the number of data points in the bootstrap sample is equivalent to the proportions in the original data set.
 #'
 #' @inheritParams vfold_cv
-#' @param times The number of bootstrap samples. 
-#' @param strata A variable that is used to conduct stratified sampling. When not `NULL`, each bootstrap sample is created within the stratification variable.
-#' @param apparent A logical. Should an extra resample be added where the analysis and holdout subset are the entire data set. This is required for some estimators used by the `summary` function that require the apparent error rate.   
+#' @param times The number of bootstrap samples.
+#' @param strata A variable that is used to conduct stratified sampling. When not `NULL`, each bootstrap sample is created within the stratification variable. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.
+#' @param apparent A logical. Should an extra resample be added where the analysis and holdout subset are the entire data set. This is required for some estimators used by the `summary` function that require the apparent error rate.
 #' @export
 #' @return  An tibble with classes `bootstraps`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and a column called `id` that has a character string with the resample identifier.
 #' @examples
 #' bootstraps(mtcars, times = 2)
 #' bootstraps(mtcars, times = 2, apparent = TRUE)
-#' 
+#'
 #' library(purrr)
 #' iris2 <- iris[1:130, ]
-#' 
+#'
 #' set.seed(13)
 #' resample1 <- bootstraps(iris2, times = 3)
 #' map_dbl(resample1$splits,
@@ -27,7 +27,7 @@
 #'           dat <- as.data.frame(x)$Species
 #'           mean(dat == "virginica")
 #'         })
-#' 
+#'
 #' set.seed(13)
 #' resample2 <- bootstraps(iris2, strata = "Species", times = 3)
 #' map_dbl(resample2$splits,
@@ -42,8 +42,13 @@ bootstraps <-
            strata = NULL,
            apparent = FALSE,
            ...) {
-    
-  strata_check(strata, names(data))  
+
+  if(!missing(strata)) {
+    strata <- tidyselect::vars_select(names(data), !!enquo(strata))
+    if(length(strata) == 0) strata <- NULL
+  }
+
+  strata_check(strata, names(data))
 
   split_objs <-
     boot_splits(
@@ -54,14 +59,14 @@ bootstraps <-
   if(apparent)
     split_objs <- bind_rows(split_objs, apparent(data))
 
-  boot_att <- list(times = times, 
-                   apparent = apparent, 
+  boot_att <- list(times = times,
+                   apparent = apparent,
                    strata = !is.null(strata))
-  
-  new_rset(splits = split_objs$splits, 
+
+  new_rset(splits = split_objs$splits,
            ids = split_objs$id,
-           attrib = boot_att, 
-           subclass = c("bootstraps", "rset")) 
+           attrib = boot_att,
+           subclass = c("bootstraps", "rset"))
 
 }
 
@@ -76,7 +81,7 @@ boot_splits <-
   function(data,
            times = 25,
            strata = NULL) {
-    
+
   n <- nrow(data)
 
   if (is.null(strata)) {
@@ -94,10 +99,10 @@ boot_splits <-
         replace = TRUE
       )
     indices <- split(stratas$idx, stratas$rs_id)
-  }  
+  }
 
   indices <- lapply(indices, boot_complement, n = n)
-  
+
   split_objs <-
     purrr::map(indices, make_splits, data = data, class = "boot_split")
   list(splits = split_objs,

--- a/R/groups.R
+++ b/R/groups.R
@@ -8,8 +8,8 @@
 #'  out at a time.
 #'
 #' @param data A data frame.
-#' @param group A single character value for the column of the
-#'  data that will be used to create the splits.
+#' @param group This could be a single character value or a variable
+#'  name that corresponds to a variable that exists in the data frame.
 #' @param v The number of partitions of the data set. If let
 #'  `NULL`, `v` will be set to the number of unique values
 #'  in the group.
@@ -41,6 +41,14 @@
 #' map_int(held_out, length)
 #' @export
 group_vfold_cv <- function(data, group = NULL, v = NULL, ...) {
+
+  if(!missing(group)) {
+    group <- tidyselect::vars_select(names(data), !!enquo(group))
+    if(length(group) == 0) {
+      group <- NULL
+    }
+  }
+
   if (is.null(group) || !is.character(group) || length(group) != 1)
     stop(
       "`group` should be a single character value for the column ",

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -10,7 +10,7 @@
 #'
 #' @inheritParams vfold_cv
 #' @param prop The proportion of data to be retained for modeling/analysis.
-#' @param strata A variable that is used to conduct stratified sampling to create the resamples.
+#' @param strata A variable that is used to conduct stratified sampling to create the resamples. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.
 #' @export
 #' @return  An `rset` object that can be used with the `training` and `testing` functions to extract the data in each split.
 #' @examples
@@ -26,6 +26,12 @@
 #' @export
 #'
 initial_split <- function(data, prop = 3/4, strata = NULL, ...) {
+
+  if(!missing(strata)) {
+    strata <- tidyselect::vars_select(names(data), !!enquo(strata))
+    if(length(strata) == 0) strata <- NULL
+  }
+
   res <-
     mc_cv(
       data = data,

--- a/R/mc.R
+++ b/R/mc.R
@@ -1,23 +1,23 @@
 #' Monte Carlo Cross-Validation
 #'
-#' One resample of Monte Carlo cross-validation takes a random sample (without replacement) of the original data set to be used for analysis. All other data points are added to the assessment set. 
+#' One resample of Monte Carlo cross-validation takes a random sample (without replacement) of the original data set to be used for analysis. All other data points are added to the assessment set.
 #'
-#' @details 
-#' The `strata` argument causes the random sampling to be conducted *within the stratification variable*. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.  
+#' @details
+#' The `strata` argument causes the random sampling to be conducted *within the stratification variable*. The can help ensure that the number of data points in the analysis data is equivalent to the proportions in the original data set.
 #'
 #' @inheritParams vfold_cv
-#' @param prop The proportion of data to be retained for modeling/analysis. 
-#' @param times The number of times to repeat the sampling.. 
-#' @param strata A variable that is used to conduct stratified sampling to create the resamples. 
+#' @param prop The proportion of data to be retained for modeling/analysis.
+#' @param times The number of times to repeat the sampling..
+#' @param strata A variable that is used to conduct stratified sampling to create the resamples. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.
 #' @export
 #' @return  An tibble with classes `mc_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and a column called `id` that has a character string with the resample identifier.
 #' @examples
 #' mc_cv(mtcars, times = 2)
 #' mc_cv(mtcars, prop = .5, times = 2)
-#' 
+#'
 #' library(purrr)
 #' iris2 <- iris[1:130, ]
-#' 
+#'
 #' set.seed(13)
 #' resample1 <- mc_cv(iris2, times = 3, prop = .5)
 #' map_dbl(resample1$splits,
@@ -25,7 +25,7 @@
 #'           dat <- as.data.frame(x)$Species
 #'           mean(dat == "virginica")
 #'         })
-#' 
+#'
 #' set.seed(13)
 #' resample2 <- mc_cv(iris2, strata = "Species", times = 3, prop = .5)
 #' map_dbl(resample2$splits,
@@ -35,28 +35,33 @@
 #'         })
 #' @export
 mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, ...) {
-  
+
+  if(!missing(strata)) {
+    strata <- tidyselect::vars_select(names(data), !!enquo(strata))
+    if(length(strata) == 0) strata <- NULL
+  }
+
   strata_check(strata, names(data))
-  
+
   split_objs <-
     mc_splits(data = data,
               prop = 1 - prop,
-              times = times, 
+              times = times,
               strata = strata)
-  
-  ## We remove the holdout indicies since it will save space and we can 
-  ## derive them later when they are needed. 
-  
+
+  ## We remove the holdout indicies since it will save space and we can
+  ## derive them later when they are needed.
+
   split_objs$splits <- map(split_objs$splits, rm_out)
-  
-  mc_att <- list(prop = prop, 
-                 times = times, 
+
+  mc_att <- list(prop = prop,
+                 times = times,
                  strata = !is.null(strata))
-  
-  new_rset(splits = split_objs$splits, 
-           ids = split_objs$id, 
-           attrib = mc_att, 
-           subclass = c("mc_cv", "rset")) 
+
+  new_rset(splits = split_objs$splits,
+           ids = split_objs$id,
+           attrib = mc_att,
+           subclass = c("mc_cv", "rset"))
 }
 
 # Get the indices of the analysis set from the assessment set
@@ -70,7 +75,7 @@ mc_complement <- function(ind, n) {
 mc_splits <- function(data, prop = 3/4, times = 25, strata = NULL) {
   if (!is.numeric(prop) | prop >= 1 | prop <= 0)
     stop("`prop` must be a number on (0, 1).", call. = FALSE)
-  
+
   n <- nrow(data)
   if (is.null(strata)) {
     indices <- purrr::map(rep(n, times), sample, size = floor(n * prop))

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -10,7 +10,7 @@
 #' @param data A data frame.
 #' @param v The number of partitions of the data set.
 #' @param repeats The number of times to repeat the V-fold partitioning.
-#' @param strata A variable that is used to conduct stratified sampling to create the folds. This should be a single character value.
+#' @param strata A variable that is used to conduct stratified sampling to create the folds. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.
 #' @param ... Not currently used.
 #' @export
 #' @return  A tibble with classes `vfold_cv`, `rset`, `tbl_df`, `tbl`, and `data.frame`. The results include a column for the data split objects and one or more identification variables. For a single repeats, there will be one column called `id` that has a character string with the fold identifier. For repeats, `id` is the repeat number and an additional column called `id2` that contains the fold information (within repeat).
@@ -38,6 +38,11 @@
 #'         })
 #' @export
 vfold_cv <- function(data, v = 10, repeats = 1, strata = NULL, ...) {
+
+  if(!missing(strata)) {
+    strata <- tidyselect::vars_select(names(data), !!enquo(strata))
+    if(length(strata) == 0) strata <- NULL
+  }
 
   strata_check(strata, names(data))
 

--- a/man/bootstraps.Rd
+++ b/man/bootstraps.Rd
@@ -11,7 +11,7 @@ bootstraps(data, times = 25, strata = NULL, apparent = FALSE, ...)
 
 \item{times}{The number of bootstrap samples.}
 
-\item{strata}{A variable that is used to conduct stratified sampling. When not \code{NULL}, each bootstrap sample is created within the stratification variable.}
+\item{strata}{A variable that is used to conduct stratified sampling. When not \code{NULL}, each bootstrap sample is created within the stratification variable. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.}
 
 \item{apparent}{A logical. Should an extra resample be added where the analysis and holdout subset are the entire data set. This is required for some estimators used by the \code{summary} function that require the apparent error rate.}
 

--- a/man/group_vfold_cv.Rd
+++ b/man/group_vfold_cv.Rd
@@ -9,8 +9,8 @@ group_vfold_cv(data, group = NULL, v = NULL, ...)
 \arguments{
 \item{data}{A data frame.}
 
-\item{group}{A single character value for the column of the
-data that will be used to create the splits.}
+\item{group}{This could be a single character value or a variable
+name that corresponds to a variable that exists in the data frame.}
 
 \item{v}{The number of partitions of the data set. If let
 \code{NULL}, \code{v} will be set to the number of unique values

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -20,7 +20,7 @@ testing(x)
 
 \item{prop}{The proportion of data to be retained for modeling/analysis.}
 
-\item{strata}{A variable that is used to conduct stratified sampling to create the resamples.}
+\item{strata}{A variable that is used to conduct stratified sampling to create the resamples. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.}
 
 \item{...}{Not currently used.}
 

--- a/man/mc_cv.Rd
+++ b/man/mc_cv.Rd
@@ -13,7 +13,7 @@ mc_cv(data, prop = 3/4, times = 25, strata = NULL, ...)
 
 \item{times}{The number of times to repeat the sampling..}
 
-\item{strata}{A variable that is used to conduct stratified sampling to create the resamples.}
+\item{strata}{A variable that is used to conduct stratified sampling to create the resamples. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.}
 
 \item{...}{Not currently used.}
 }

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -13,7 +13,7 @@ vfold_cv(data, v = 10, repeats = 1, strata = NULL, ...)
 
 \item{repeats}{The number of times to repeat the V-fold partitioning.}
 
-\item{strata}{A variable that is used to conduct stratified sampling to create the folds. This should be a single character value.}
+\item{strata}{A variable that is used to conduct stratified sampling to create the folds. This could be a single character value or a variable name that corresponds to a variable that exists in the data frame.}
 
 \item{...}{Not currently used.}
 }

--- a/tests/testthat/test_boot.R
+++ b/tests/testthat/test_boot.R
@@ -73,8 +73,7 @@ test_that('strata', {
 
 test_that('bad args', {
   expect_error(bootstraps(iris, strata = iris$Species))
-  expect_error(bootstraps(iris, strata = 2))
-  expect_error(bootstraps(iris, strata = c("Species", "Species")))
+  expect_error(bootstraps(iris, strata = c("Species", "Sepal.Length")))
 })
 
 

--- a/tests/testthat/test_mc.R
+++ b/tests/testthat/test_mc.R
@@ -70,8 +70,7 @@ test_that('strata', {
 
 test_that('bad args', {
   expect_error(mc_cv(iris, strata = iris$Species))
-  expect_error(mc_cv(iris, strata = 2))
-  expect_error(mc_cv(iris, strata = c("Species", "Species")))
+  expect_error(mc_cv(iris, strata = c("Species", "Sepal.Length")))
 })
 
 

--- a/tests/testthat/test_vfold.R
+++ b/tests/testthat/test_vfold.R
@@ -70,8 +70,7 @@ test_that('strata', {
 
 test_that('bad args', {
   expect_error(vfold_cv(iris, strata = iris$Species))
-  expect_error(vfold_cv(iris, strata = 2))
-  expect_error(vfold_cv(iris, strata = c("Species", "Species")))
+  expect_error(vfold_cv(iris, strata = c("Species", "Sepal.Width")))
 })
 
 test_that('printing', {


### PR DESCRIPTION
Eliminated these tests

`expect_error(mc_cv(iris, strata = 2))`
`expect_error(vfold_cv(iris, strata = 2))`
  
So user can specify strata by index of column as it is behavior familiar from tidyselect

Closes #95 