### PR TITLE
Expect warnings around noisy tests

### DIFF
--- a/tests/testthat/test_bootci.R
+++ b/tests/testthat/test_bootci.R
@@ -139,17 +139,26 @@ test_that('Upper & lower confidence interval does not contain NA', {
     mutate(res = map(splits, bad_stats))
 
   expect_error(
-    int_pctl(bt_resamples, res),
+    expect_warning(
+      int_pctl(bt_resamples, res),
+      "at least 1000 non-missing"
+    ),
     "missing values"
   )
 
   expect_error(
-    int_t(bt_resamples, res),
+    expect_warning(
+      int_t(bt_resamples, res),
+      "at least 1000 non-missing"
+    ),
     "missing values"
   )
 
   expect_error(
-    int_bca(bt_resamples, res, .fn = bad_stats),
+    expect_warning(
+      int_bca(bt_resamples, res, .fn = bad_stats),
+      "at least 1000 non-missing"
+    ),
     "missing values"
   )
 

--- a/tests/testthat/test_strata.R
+++ b/tests/testthat/test_strata.R
@@ -11,7 +11,7 @@ test_that('simple numerics', {
   tab1a <- table(str1a)
   expect_equal(as.vector(tab1a), rep(250, 4))
 
-  str1b <- make_strata(x1, depth = 500)
+  str1b <- expect_warning(make_strata(x1, depth = 500), "2 breaks instead")
   tab1b <- table(str1b)
   expect_equal(as.vector(tab1b), rep(500, 2))
 })


### PR DESCRIPTION
A few tests were noisy because their warnings were not being captured