### PR TITLE
Update print method for rsplit object

### DIFF
--- a/R/rsplit.R
+++ b/R/rsplit.R
@@ -32,6 +32,7 @@ print.rsplit <- function(x, ...) {
   else
     paste(length(x$out_id))
 
+  cat("<Training/Testing/Total>\n")
   cat("<",
       length(x$in_id), "/",
       out_char, "/",


### PR DESCRIPTION
Adds another line to print.rsplit to indicate what each number means.

``` r
library(rsample)
#> Loading required package: tidyr
initial_split(mtcars)
#> <Training/Testing/Total>
#> <24/8/32>
```

Doesn't break tibble print

``` r
vfold_cv(mtcars, v = 2)
#> #  2-fold cross-validation 
#> # A tibble: 2 x 2
#>   splits          id   
#>   <named list>    <chr>
#> 1 <split [16/16]> Fold1
#> 2 <split [16/16]> Fold2

vfold_cv(mtcars, v = 2)$splits[[1]]
#> <Training/Testing/Total>
#> <16/16/32>
```

<sup>Created on 2020-01-31 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup>