### PR TITLE
Rolling Origin & Initial Time Split: Lag parameter

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,5 +37,5 @@ License: GPL-2
 Encoding: UTF-8
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 7.0.2.9000
+RoxygenNote: 7.1.0
 Roxygen: list(markdown = TRUE)

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -26,8 +26,15 @@
 #'
 #' drinks_split <- initial_time_split(drinks)
 #' train_data <- training(drinks_split)
-#' test_data <- testing(car_split)
+#' test_data <- testing(drinks_split)
 #' c(max(train_data$date), min(test_data$date))  # no overlap
+#'
+#' # With 12 period overlap
+#' drinks_overlap_split <- initial_time_split(drinks, overlap = 12)
+#' train_data <- training(drinks_overlap_split)
+#' test_data <- testing(drinks_overlap_split)
+#' c(max(train_data$date), min(test_data$date))  # 12 period overlap
+#'
 #' @export
 #'
 initial_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
@@ -50,8 +57,11 @@ initial_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
 }
 
 #' @rdname initial_split
+#' @param overlap A value to include an overlap between the assessment
+#'  and analysis set. This is useful if lagged predictors will be used
+#'  during training and testing.
 #' @export
-initial_time_split <- function(data, prop = 3/4, ...) {
+initial_time_split <- function(data, prop = 3/4, overlap = 0, ...) {
 
   if (!is.numeric(prop) | prop >= 1 | prop <= 0) {
     stop("`prop` must be a number on (0, 1).", call. = FALSE)
@@ -59,7 +69,7 @@ initial_time_split <- function(data, prop = 3/4, ...) {
 
   n_train <- floor(nrow(data) * prop)
 
-  rsplit(data, 1:n_train, (n_train + 1):nrow(data))
+  rsplit(data, 1:n_train, (n_train + 1 - overlap):nrow(data))
 }
 
 #' @rdname initial_split

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -27,13 +27,13 @@
 #' drinks_split <- initial_time_split(drinks)
 #' train_data <- training(drinks_split)
 #' test_data <- testing(drinks_split)
-#' c(max(train_data$date), min(test_data$date))  # no overlap
+#' c(max(train_data$date), min(test_data$date))  # no lag
 #'
-#' # With 12 period overlap
-#' drinks_overlap_split <- initial_time_split(drinks, overlap = 12)
-#' train_data <- training(drinks_overlap_split)
-#' test_data <- testing(drinks_overlap_split)
-#' c(max(train_data$date), min(test_data$date))  # 12 period overlap
+#' # With 12 period lag
+#' drinks_lag_split <- initial_time_split(drinks, lag = 12)
+#' train_data <- training(drinks_lag_split)
+#' test_data <- testing(drinks_lag_split)
+#' c(max(train_data$date), min(test_data$date))  # 12 period lag
 #'
 #' @export
 #'
@@ -57,19 +57,27 @@ initial_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
 }
 
 #' @rdname initial_split
-#' @param overlap A value to include an overlap between the assessment
+#' @param lag A value to include an lag between the assessment
 #'  and analysis set. This is useful if lagged predictors will be used
 #'  during training and testing.
 #' @export
-initial_time_split <- function(data, prop = 3/4, overlap = 0, ...) {
+initial_time_split <- function(data, prop = 3/4, lag = 0, ...) {
 
   if (!is.numeric(prop) | prop >= 1 | prop <= 0) {
     stop("`prop` must be a number on (0, 1).", call. = FALSE)
   }
 
+  if (!is.numeric(lag) | !(lag%%1==0)) {
+    stop("`lag` must be a whole number.", call. = FALSE)
+  }
+
   n_train <- floor(nrow(data) * prop)
 
-  rsplit(data, 1:n_train, (n_train + 1 - overlap):nrow(data))
+  if (lag > n_train) {
+    stop("`lag` must be less than the number of training observations.", call. = FALSE)
+  }
+
+  rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))
 }
 
 #' @rdname initial_split

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -74,7 +74,7 @@ initial_time_split <- function(data, prop = 3/4, lag = 0, ...) {
   n_train <- floor(nrow(data) * prop)
 
   if (lag > n_train) {
-    stop("`lag` must be less than the number of training observations.", call. = FALSE)
+    stop("`lag` must be less than or equal to the number of training observations.", call. = FALSE)
   }
 
   rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))

--- a/R/rolling_origin.R
+++ b/R/rolling_origin.R
@@ -23,6 +23,9 @@
 #' @param skip A integer indicating how many (if any) _additional_ resamples
 #'  to skip to thin the total amount of data points in the analysis resample.
 #' See the example below.
+#' @param overlap A value to include an overlap between the assessment
+#'  and analysis set. This is useful if lagged predictors will be used
+#'  during training and testing.
 #' @export
 #' @return An tibble with classes `rolling_origin`, `rset`, `tbl_df`, `tbl`,
 #'  and `data.frame`. The results include a column for the data split objects
@@ -52,7 +55,7 @@
 #'
 #' @export
 rolling_origin <- function(data, initial = 5, assess = 1,
-                           cumulative = TRUE, skip = 0, ...) {
+                           cumulative = TRUE, skip = 0, overlap = 0, ...) {
   n <- nrow(data)
 
   if (n < initial + assess)
@@ -69,7 +72,7 @@ rolling_origin <- function(data, initial = 5, assess = 1,
 
   in_ind <- mapply(seq, starts, stops, SIMPLIFY = FALSE)
   out_ind <-
-    mapply(seq, stops + 1, stops + assess, SIMPLIFY = FALSE)
+    mapply(seq, stops + 1 - overlap, stops + assess, SIMPLIFY = FALSE)
   indices <- mapply(merge_lists, in_ind, out_ind, SIMPLIFY = FALSE)
   split_objs <-
     purrr::map(indices, make_splits, data = data, class = "rof_split")
@@ -79,7 +82,8 @@ rolling_origin <- function(data, initial = 5, assess = 1,
   roll_att <- list(initial = initial,
                    assess = assess,
                    cumulative = cumulative,
-                   skip = skip)
+                   skip = skip,
+                   overlap = overlap)
 
   new_rset(splits = split_objs$splits,
            ids = split_objs$id,

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -9,7 +9,7 @@
 \usage{
 initial_split(data, prop = 3/4, strata = NULL, breaks = 4, ...)
 
-initial_time_split(data, prop = 3/4, overlap = 0, ...)
+initial_time_split(data, prop = 3/4, lag = 0, ...)
 
 training(x)
 
@@ -29,7 +29,7 @@ a numeric stratification variable.}
 
 \item{...}{Not currently used.}
 
-\item{overlap}{A value to include an overlap between the assessment
+\item{lag}{A value to include an lag between the assessment
 and analysis set. This is useful if lagged predictors will be used
 during training and testing.}
 
@@ -60,12 +60,12 @@ test_data <- testing(car_split)
 drinks_split <- initial_time_split(drinks)
 train_data <- training(drinks_split)
 test_data <- testing(drinks_split)
-c(max(train_data$date), min(test_data$date))  # no overlap
+c(max(train_data$date), min(test_data$date))  # no lag
 
-# With 12 period overlap
-drinks_overlap_split <- initial_time_split(drinks, overlap = 12)
-train_data <- training(drinks_overlap_split)
-test_data <- testing(drinks_overlap_split)
-c(max(train_data$date), min(test_data$date))  # 12 period overlap
+# With 12 period lag
+drinks_lag_split <- initial_time_split(drinks, lag = 12)
+train_data <- training(drinks_lag_split)
+test_data <- testing(drinks_lag_split)
+c(max(train_data$date), min(test_data$date))  # 12 period lag
 
 }

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -9,7 +9,7 @@
 \usage{
 initial_split(data, prop = 3/4, strata = NULL, breaks = 4, ...)
 
-initial_time_split(data, prop = 3/4, ...)
+initial_time_split(data, prop = 3/4, overlap = 0, ...)
 
 training(x)
 
@@ -28,6 +28,10 @@ name that corresponds to a variable that exists in the data frame.}
 a numeric stratification variable.}
 
 \item{...}{Not currently used.}
+
+\item{overlap}{A value to include an overlap between the assessment
+and analysis set. This is useful if lagged predictors will be used
+during training and testing.}
 
 \item{x}{An \code{rsplit} object produced by \code{initial_split}}
 }
@@ -55,6 +59,13 @@ test_data <- testing(car_split)
 
 drinks_split <- initial_time_split(drinks)
 train_data <- training(drinks_split)
-test_data <- testing(car_split)
+test_data <- testing(drinks_split)
 c(max(train_data$date), min(test_data$date))  # no overlap
+
+# With 12 period overlap
+drinks_overlap_split <- initial_time_split(drinks, overlap = 12)
+train_data <- training(drinks_overlap_split)
+test_data <- testing(drinks_overlap_split)
+c(max(train_data$date), min(test_data$date))  # 12 period overlap
+
 }

--- a/man/rolling_origin.Rd
+++ b/man/rolling_origin.Rd
@@ -10,7 +10,7 @@ rolling_origin(
   assess = 1,
   cumulative = TRUE,
   skip = 0,
-  overlap = 0,
+  lag = 0,
   ...
 )
 }
@@ -29,7 +29,7 @@ size specified by \code{initial} at each resample?.}
 to skip to thin the total amount of data points in the analysis resample.
 See the example below.}
 
-\item{overlap}{A value to include an overlap between the assessment
+\item{lag}{A value to include an lag between the assessment
 and analysis set. This is useful if lagged predictors will be used
 during training and testing.}
 

--- a/man/rolling_origin.Rd
+++ b/man/rolling_origin.Rd
@@ -4,7 +4,15 @@
 \alias{rolling_origin}
 \title{Rolling Origin Forecast Resampling}
 \usage{
-rolling_origin(data, initial = 5, assess = 1, cumulative = TRUE, skip = 0, ...)
+rolling_origin(
+  data,
+  initial = 5,
+  assess = 1,
+  cumulative = TRUE,
+  skip = 0,
+  overlap = 0,
+  ...
+)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -20,6 +28,10 @@ size specified by \code{initial} at each resample?.}
 \item{skip}{A integer indicating how many (if any) \emph{additional} resamples
 to skip to thin the total amount of data points in the analysis resample.
 See the example below.}
+
+\item{overlap}{A value to include an overlap between the assessment
+and analysis set. This is useful if lagged predictors will be used
+during training and testing.}
 
 \item{...}{Not currently used.}
 }

--- a/tests/testthat/test_initial.R
+++ b/tests/testthat/test_initial.R
@@ -25,3 +25,14 @@ test_that('default time param', {
   expect_equal(nrow(ts1), ceiling(nrow(dat1) / 4))
   expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3/4)))
 })
+
+test_that('default time param with overlap', {
+  rs1 <- initial_time_split(dat1, overlap = 5)
+  expect_equal(class(rs1), "rsplit")
+  tr1 <- training(rs1)
+  ts1 <- testing(rs1)
+  expect_equal(nrow(tr1), floor(nrow(dat1) * 3/4))
+  expect_equal(nrow(ts1), ceiling(nrow(dat1) / 4) + 5)
+  expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3/4)) )
+  expect_equal(ts1, dat1[(floor(nrow(dat1) * 3/4) + 1 - 5):nrow(dat1),] )
+})

--- a/tests/testthat/test_initial.R
+++ b/tests/testthat/test_initial.R
@@ -26,8 +26,8 @@ test_that('default time param', {
   expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3/4)))
 })
 
-test_that('default time param with overlap', {
-  rs1 <- initial_time_split(dat1, overlap = 5)
+test_that('default time param with lag', {
+  rs1 <- initial_time_split(dat1, lag = 5)
   expect_equal(class(rs1), "rsplit")
   tr1 <- training(rs1)
   ts1 <- testing(rs1)
@@ -35,4 +35,8 @@ test_that('default time param with overlap', {
   expect_equal(nrow(ts1), ceiling(nrow(dat1) / 4) + 5)
   expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3/4)) )
   expect_equal(ts1, dat1[(floor(nrow(dat1) * 3/4) + 1 - 5):nrow(dat1),] )
+
+  expect_error(initial_time_split(drinks, lag = 12.5)) # Whole numbers only
+  expect_error(initial_time_split(drinks, lag = 500))  # Lag must be less than number of training observations
+
 })

--- a/tests/testthat/test_rolling.R
+++ b/tests/testthat/test_rolling.R
@@ -77,20 +77,22 @@ test_that('skipping', {
 
 })
 
-test_that('overlap', {
-  rs5 <- rolling_origin(dat1, initial = 5, assess = 1, cumulative = FALSE, skip = 0, overlap = 3)
+test_that('lag', {
+  rs5 <- rolling_origin(dat1, initial = 5, assess = 1, cumulative = FALSE, skip = 0, lag = 3)
   sizes5 <- dim_rset(rs5)
 
-  expect_true(all(sizes5$assessment == attr(rs5, "assess") + attr(rs5, "overlap")))
+  expect_true(all(sizes5$assessment == attr(rs5, "assess") + attr(rs5, "lag")))
   expect_true(all(sizes5$analysis == attr(rs5, "initial")))
 
   for (i in 1:nrow(rs5)) {
     expect_equal(rs5$splits[[i]]$in_id,
                  i:(i + attr(rs5, "initial") - 1))
     expect_equal(rs5$splits[[i]]$out_id,
-                 (i + attr(rs5, "initial") - attr(rs5, "overlap")):(i + attr(rs5, "initial") + attr(rs5, "assess") - 1))
+                 (i + attr(rs5, "initial") - attr(rs5, "lag")):(i + attr(rs5, "initial") + attr(rs5, "assess") - 1))
   }
 
+  expect_error(rolling_origin(drinks, initial = 5, lag = 6)) # lag must be less than training observations
+  expect_error(olling_origin(drinks, lag = 2.1))             # lag must be whole number
 })
 
 test_that('rsplit labels', {

--- a/tests/testthat/test_rolling.R
+++ b/tests/testthat/test_rolling.R
@@ -77,8 +77,20 @@ test_that('skipping', {
 
 })
 
-test_that('printing', {
-  expect_output(print(rolling_origin(dat1)))
+test_that('overlap', {
+  rs5 <- rolling_origin(dat1, initial = 5, assess = 1, cumulative = FALSE, skip = 0, overlap = 3)
+  sizes5 <- dim_rset(rs5)
+
+  expect_true(all(sizes5$assessment == attr(rs5, "assess") + attr(rs5, "overlap")))
+  expect_true(all(sizes5$analysis == attr(rs5, "initial")))
+
+  for (i in 1:nrow(rs5)) {
+    expect_equal(rs5$splits[[i]]$in_id,
+                 i:(i + attr(rs5, "initial") - 1))
+    expect_equal(rs5$splits[[i]]$out_id,
+                 (i + attr(rs5, "initial") - attr(rs5, "overlap")):(i + attr(rs5, "initial") + attr(rs5, "assess") - 1))
+  }
+
 })
 
 test_that('rsplit labels', {


### PR DESCRIPTION
As described in #135, the `rolling_origin()` and `initial_time_split()` functions have a proposed modification to add an `overlap` parameter, which is necessary to perform resamples and train/test validation with lagged predictors when sample sizes are very low.

``` r
# - Add overlap parameter to initial_time_split() & rolling_origin()

# Libraries
library(recipes)
library(rsample)
library(tidyverse)

# 3 years of data
drinks_subset <- drinks %>% tail(36)

splits_no_overlap <- initial_time_split(drinks_subset, prop = 2/3, overlap = 0)

training(splits_no_overlap)
#> # A tibble: 24 x 2
#>    date       S4248SM144NCEN
#>    <date>              <dbl>
#>  1 2014-10-01          11817
#>  2 2014-11-01          10470
#>  3 2014-12-01          13310
#>  4 2015-01-01           8400
#>  5 2015-02-01           9062
#>  6 2015-03-01          10722
#>  7 2015-04-01          11107
#>  8 2015-05-01          11508
#>  9 2015-06-01          12904
#> 10 2015-07-01          11869
#> # … with 14 more rows

testing(splits_no_overlap)
#> # A tibble: 12 x 2
#>    date       S4248SM144NCEN
#>    <date>              <dbl>
#>  1 2016-10-01          11914
#>  2 2016-11-01          13025
#>  3 2016-12-01          14431
#>  4 2017-01-01           9049
#>  5 2017-02-01          10458
#>  6 2017-03-01          12489
#>  7 2017-04-01          11499
#>  8 2017-05-01          13553
#>  9 2017-06-01          14740
#> 10 2017-07-01          11424
#> 11 2017-08-01          13412
#> 12 2017-09-01          11917

# Without overlap - Get missing values in testing dataset 
rec_lag <- recipe(~ ., data = training(splits_no_overlap)) %>%
  step_lag(S4248SM144NCEN, lag = 12) 

bake(prep(rec_lag), testing(splits_no_overlap)) %>% tail(12) # Missing values
#> # A tibble: 12 x 3
#>    date       S4248SM144NCEN lag_12_S4248SM144NCEN
#>    <date>              <dbl>                 <dbl>
#>  1 2016-10-01          11914                    NA
#>  2 2016-11-01          13025                    NA
#>  3 2016-12-01          14431                    NA
#>  4 2017-01-01           9049                    NA
#>  5 2017-02-01          10458                    NA
#>  6 2017-03-01          12489                    NA
#>  7 2017-04-01          11499                    NA
#>  8 2017-05-01          13553                    NA
#>  9 2017-06-01          14740                    NA
#> 10 2017-07-01          11424                    NA
#> 11 2017-08-01          13412                    NA
#> 12 2017-09-01          11917                    NA

# With overlap - No missing values
splits_with_overlap <- initial_time_split(
  drinks_subset, 
  prop    = 2/3, 
  overlap = 12 # New parameter
)

rec_lag <- recipe(~ ., data = training(splits_with_overlap)) %>%
  step_lag(S4248SM144NCEN, lag = 12) 

bake(prep(rec_lag), testing(splits_with_overlap)) %>% tail(12) # Get the right values
#> # A tibble: 12 x 3
#>    date       S4248SM144NCEN lag_12_S4248SM144NCEN
#>    <date>              <dbl>                 <dbl>
#>  1 2016-10-01          11914                    11983
#>  2 2016-11-01          13025                    11506
#>  3 2016-12-01          14431                    14183
#>  4 2017-01-01           9049                    8650
#>  5 2017-02-01          10458                    10323
#>  6 2017-03-01          12489                    12110
#>  7 2017-04-01          11499                    11424
#>  8 2017-05-01          13553                    12243
#>  9 2017-06-01          14740                    13686
#> 10 2017-07-01          11424                    10956
#> 11 2017-08-01          13412                    12706
#> 12 2017-09-01          11917                    12279
```

<sup>Created on 2020-03-26 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0)</sup> 

