### PR TITLE
Bca bug calc

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@
 * Three new time based resampling functions have been added: `sliding_window()`,
   `sliding_index()`, and `sliding_period()`, which have more flexibility than
   the pre-existing `rolling_origin()`.
+  
+* Correct passing `alpha` parameter for `int_bca()` (#179).
 
 # rsample 0.0.7
 

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -341,7 +341,7 @@ bca_calc <- function(stats, orig_data, alpha = 0.05, .fn, ...) {
   }
 
   ### Estimating Z0 bias-correction
-  bias_corr_stats <- get_p0(stats)
+  bias_corr_stats <- get_p0(stats, alpha=alpha)
 
   # need the original data frame here
   loo_rs <- loo_cv(orig_data)

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -341,7 +341,7 @@ bca_calc <- function(stats, orig_data, alpha = 0.05, .fn, ...) {
   }
 
   ### Estimating Z0 bias-correction
-  bias_corr_stats <- get_p0(stats, alpha=alpha)
+  bias_corr_stats <- get_p0(stats, alpha = alpha)
 
   # need the original data frame here
   loo_rs <- loo_cv(orig_data)

--- a/tests/testthat/test_bootci.R
+++ b/tests/testthat/test_bootci.R
@@ -52,43 +52,43 @@ test_that('Bootstrap estimate of mean is close to estimate of mean from normal d
 
   expect_equal(ttest$conf.low,
                single_pct_res$.lower,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(unname(ttest$estimate),
                single_pct_res$.estimate,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(ttest$conf.high,
                single_pct_res$.upper,
-               tolerance = 0.01)
+               tolerance = 0.001)
 
   expect_equal(ttest$conf.low,
                single_t_res$.lower,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(unname(ttest$estimate),
                single_t_res$.estimate,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(ttest$conf.high,
                single_pct_res$.upper,
-               tolerance = 0.01)
+               tolerance = 0.001)
 
   expect_equal(ttest$conf.low,
                single_bca_res$.lower,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(unname(ttest$estimate),
                single_bca_res$.estimate,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(ttest$conf.high,
                single_bca_res$.upper,
-               tolerance = 0.01)
+               tolerance = 0.001)
 
   expect_equal(ttest_lower_conf$conf.low,
                single_bca_res_lower_conf$.lower,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(unname(ttest_lower_conf$estimate),
                single_bca_res_lower_conf$.estimate,
-               tolerance = 0.01)
+               tolerance = 0.001)
   expect_equal(ttest_lower_conf$conf.high,
                single_bca_res_lower_conf$.upper,
-               tolerance = 0.01)
+               tolerance = 0.001)
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test_bootci.R
+++ b/tests/testthat/test_bootci.R
@@ -30,6 +30,7 @@ sigma <- 1
 set.seed(888)
 rand_nums <- rnorm(n, mu, sigma)
 ttest <- tidy(t.test(rand_nums))
+ttest_lower_conf <- tidy(t.test(rand_nums, conf.level = 0.8))
 dat <- data.frame(x = rand_nums)
 
 set.seed(456765)
@@ -46,6 +47,8 @@ test_that('Bootstrap estimate of mean is close to estimate of mean from normal d
   single_t_res <- int_t(bt_norm, stats)
 
   single_bca_res <- int_bca(bt_norm, stats, .fn = get_stats)
+
+  single_bca_res_lower_conf <- int_bca(bt_norm, stats, .fn = get_stats, alpha = 0.2)
 
   expect_equal(ttest$conf.low,
                single_pct_res$.lower,
@@ -75,6 +78,16 @@ test_that('Bootstrap estimate of mean is close to estimate of mean from normal d
                tolerance = 0.01)
   expect_equal(ttest$conf.high,
                single_bca_res$.upper,
+               tolerance = 0.01)
+
+  expect_equal(ttest_lower_conf$conf.low,
+               single_bca_res_lower_conf$.lower,
+               tolerance = 0.01)
+  expect_equal(unname(ttest_lower_conf$estimate),
+               single_bca_res_lower_conf$.estimate,
+               tolerance = 0.01)
+  expect_equal(ttest_lower_conf$conf.high,
+               single_bca_res_lower_conf$.upper,
                tolerance = 0.01)
 })
 


### PR DESCRIPTION
In #177, @juliasilge mentions the bug may be because `alpha` is not passed to `get_p0`.  This PR fixes that and adds additional unit tests to ensure `int_bca` returns appropriate confidence limits when the confidence level changes.