### PR TITLE
Validate single numeric value for alpha argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,7 +7,7 @@
   `sliding_index()`, and `sliding_period()`, which have more flexibility than
   the pre-existing `rolling_origin()`.
   
-* Correct passing `alpha` parameter for `int_bca()` (#179).
+* Correct `alpha` parameter handling for bootstrap CI functions (#179, #184).
 
 # rsample 0.0.7
 

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -239,6 +239,9 @@ pctl_single <- function(stats, alpha = 0.05) {
 int_pctl <- function(.data, statistics, alpha = 0.05) {
 
   check_rset(.data, app = FALSE)
+  if (length(alpha) != 1 || !is.numeric(alpha)) {
+    abort("`alpha` must be a single numeric value.")
+  }
 
   .data <- .data %>% dplyr::filter(id != "Apparent")
 
@@ -312,6 +315,9 @@ t_single <- function(stats, std_err, is_orig, alpha = 0.05) {
 int_t <- function(.data, statistics, alpha = 0.05) {
 
   check_rset(.data)
+  if (length(alpha) != 1 || !is.numeric(alpha)) {
+    abort("`alpha` must be a single numeric value.")
+  }
 
   column_name <- tidyselect::vars_select(names(.data), !!enquo(statistics))
   if (length(column_name) != 1) {
@@ -410,6 +416,9 @@ bca_calc <- function(stats, orig_data, alpha = 0.05, .fn, ...) {
 int_bca <- function(.data, statistics, alpha = 0.05, .fn, ...) {
 
   check_rset(.data)
+  if (length(alpha) != 1 || !is.numeric(alpha)) {
+    abort("`alpha` must be a single numeric value.")
+  }
 
   has_dots(.fn)
 

--- a/tests/testthat/test_bootci.R
+++ b/tests/testthat/test_bootci.R
@@ -206,6 +206,10 @@ context("boot_ci() Input Validation")
 test_that("bad input", {
   expect_error(int_pctl(bt_small, id))
   expect_error(int_pctl(bt_small, junk))
+  expect_error(int_pctl(bt_small, stats, alpha = c(0.05, 0.2)))
+  expect_error(int_t(bt_small, stats, alpha = "potato"))
+  expect_error(int_bca(bt_small, stats, alpha = 1:2, .fn = get_stats))
+
 
   bad_bt_norm <-
     bt_norm %>%


### PR DESCRIPTION
This PR closes #180 by validating that the `alpha` argument for the three bootstrap CI functions is a single numeric value.

``` r
library(tidyverse)
library(rsample)
library(broom)

lm_est <- function(split, ...) {
  lm(mpg ~ disp + hp, data = analysis(split)) %>%
    tidy()
}

set.seed(52156)

car_rs <-
  bootstraps(mtcars, 200, apparent = TRUE) %>%
  mutate(results = map(splits, lm_est))

int_pctl(car_rs, results, alpha = c(0.05, 0.2))
#> Error: `alpha` must be a single numeric value.
#> Backtrace:
#>     █
#>  1. └─rsample::int_pctl(car_rs, results, alpha = c(0.05, 0.2))
int_t(car_rs, results, alpha = "potato")
#> Error: `alpha` must be a single numeric value.
#> Backtrace:
#>     █
#>  1. └─rsample::int_t(car_rs, results, alpha = "potato")
int_bca(car_rs, results, alpha = 1:4, .fn = lm_est)
#> Error: `alpha` must be a single numeric value.
#> Backtrace:
#>     █
#>  1. └─rsample::int_bca(car_rs, results, alpha = 1:4, .fn = lm_est)

int_bca(car_rs, results, alpha = 0.2, .fn = lm_est)
#> Warning: Recommend at least 1000 non-missing bootstrap resamples for terms:
#> `(Intercept)`, `disp`, `hp`.
#> # A tibble: 3 x 6
#>   term         .lower .estimate  .upper .alpha .method
#>   <chr>         <dbl>     <dbl>   <dbl>  <dbl> <chr>  
#> 1 (Intercept) 28.5      30.9    32.6       0.2 BCa    
#> 2 disp        -0.0425   -0.0299 -0.0221    0.2 BCa    
#> 3 hp          -0.0426   -0.0270 -0.0149    0.2 BCa
```

<sup>Created on 2020-09-14 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>