### PR TITLE
Fix issue of when to generate the complement set

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* Fixed an issue where empty assessment sets couldn't be created by `make_splits()` (#188).
+
 # rsample 0.0.8
 
 * New `manual_rset()` for constructing rset objects manually from custom rsplits (tidymodels/tune#273).

--- a/R/complement.R
+++ b/R/complement.R
@@ -21,7 +21,7 @@ complement <- function(x, ...)
 
 #' @export
 complement.vfold_split <- function(x, ...) {
-  if (!all(is.na(x$out_id))) {
+  if (!is_missing_out_id(x)) {
     return(x$out_id)
   } else {
     setdiff(1:nrow(x$data), x$in_id)
@@ -37,7 +37,7 @@ complement.loo_split <- complement.vfold_split
 complement.group_vfold_split <- complement.vfold_split
 #' @export
 complement.boot_split <- function(x, ...) {
-  if (!all(is.na(x$out_id))) {
+  if (!is_missing_out_id(x)) {
     return(x$out_id)
   } else {
     (1:nrow(x$data))[-unique(x$in_id)]
@@ -76,7 +76,7 @@ get_stored_out_id <- function(x) {
 
 #' @export
 complement.apparent_split <- function(x, ...) {
-  if (!all(is.na(x$out_id))) {
+  if (!is_missing_out_id(x)) {
     return(x$out_id)
   } else {
     1:nrow(x$data)
@@ -122,5 +122,9 @@ populate.rset <- function(x, ...) {
 rm_out <- function(x) {
   x$out_id <- NA
   x
+}
+
+is_missing_out_id <- function(x) {
+  identical(x$out_id, NA)
 }
 

--- a/R/rsplit.R
+++ b/R/rsplit.R
@@ -27,7 +27,7 @@ rsplit <- function(data, in_id, out_id) {
 #' @export
 print.rsplit <- function(x, ...) {
   out_char <-
-    if (all(is.na(x$out_id)))
+    if (is_missing_out_id(x))
       paste(length(complement(x)))
   else
     paste(length(x$out_id))
@@ -47,7 +47,7 @@ as.integer.rsplit <-
     if (data == "analysis")
       out <- x$in_id
     else {
-      out <- if (all(is.na(x$out_id)))
+      out <- if (is_missing_out_id(x))
         complement(x)
       else
         x$out_id
@@ -122,7 +122,7 @@ dim.rsplit <- function(x, ...) {
 #' @export
 obj_sum.rsplit <- function(x, ...) {
   out_char <-
-    if (all(is.na(x$out_id)))
+    if (is_missing_out_id(x))
       paste(length(complement(x)))
   else
     paste(length(x$out_id))
@@ -137,7 +137,7 @@ obj_sum.rsplit <- function(x, ...) {
 #' @export
 type_sum.rsplit <- function(x, ...) {
   out_char <-
-    if (all(is.na(x$out_id)))
+    if (is_missing_out_id(x))
       format_n(length(complement(x)))
   else
     format_n(length(x$out_id))

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -66,7 +66,7 @@ print.validation_split <- function(x, ...) {
 #' @export
 print.val_split<- function(x, ...) {
 
-  if (all(is.na(x$out_id))) {
+  if (is_missing_out_id(x)) {
     out_char <- paste(length(complement(x)))
   } else {
     out_char <- paste(length(x$out_id))

--- a/tests/testthat/test-make-splits.R
+++ b/tests/testthat/test-make-splits.R
@@ -1,0 +1,16 @@
+test_that("can create a split with an empty assessment set (#188)", {
+  df <- data.frame(x = c(1, 2, 3, 4))
+  indices <- list(analysis = 1:4, assessment = integer())
+
+  split <- make_splits(indices, df)
+
+  expect_identical(split$out_id, integer())
+  expect_identical(assessment(split), df[0, , drop = FALSE])
+})
+
+test_that("cannot create a split with an empty analysis set", {
+  df <- data.frame(x = c(1, 2, 3, 4))
+  indices <- list(analysis = integer(), assessment = 1:4)
+
+  expect_error(make_splits(indices, df), "At least one row")
+})


### PR DESCRIPTION
Closes #188 

This issue boils down to the following behavior, which has to hold true for algebraic purposes, but can sometimes bite you:

``` r
out_id <- integer()

# are all values NA?
all(is.na(out_id))
#> [1] TRUE
```

<sup>Created on 2020-10-05 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

We used a check like this to determine if we needed to generate the `complement()` set or not. We actually wanted the empty set to be a "valid" assessment set, so in this case ideally we wouldn't need to generate the complement, but the check was returning the wrong result due to this `all()` behavior above.

Since our "signal" for needing to generate the complement is really just a single `NA` value from using `rm_out()`, I've added a `is_missing_out_id()` that just checks if `$out_id` is identical to `NA`. I then replaced all calls to this `all(is.na())` behavior with `is_missing_out_id()`, which fixes the issue.