### PR TITLE
GH actions updates

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -33,9 +33,8 @@ jobs:
           - {os: ubuntu-16.04,   r: 'release', rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: 'oldrel',  rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
           - {os: ubuntu-16.04,   r: '3.5',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          # until lava > 1.6.8 is sent to CRAN
-          # - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
-          # - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.4',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
+          - {os: ubuntu-16.04,   r: '3.3',     rspm: "https://packagemanager.rstudio.com/cran/__linux__/xenial/latest"}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/pkgdown.yaml
+++ b/.github/workflows/pkgdown.yaml
@@ -1,6 +1,12 @@
 on:
   push:
-    branches: [main, master]
+    branches:
+      - master
+      - main
+  pull_request:
+    branches:
+      - master
+      - main
 
 name: pkgdown
 
@@ -15,6 +21,9 @@ jobs:
       - uses: r-lib/actions/setup-r@v1
 
       - uses: r-lib/actions/setup-pandoc@v1
+
+      - name: System dependencies
+        run: brew install harfbuzz fribidi
 
       - name: Query dependencies
         run: |
@@ -32,9 +41,9 @@ jobs:
 
       - name: Install dependencies
         run: |
-          remotes::install_deps(dependencies = TRUE, type = "binary")
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_github("tidyverse/tidytemplate")
           install.packages("pkgdown", type = "binary")
-          remotes::install_github("tidyverse/tidytemplate", type = "binary")
         shell: Rscript {0}
 
       - name: Install article dependencies
@@ -49,7 +58,13 @@ jobs:
       - name: Install package
         run: R CMD INSTALL .
 
+      - name: Build site
+        if: github.event_name == 'pull_request'
+        run: |
+          Rscript -e 'pkgdown::build_site()'
+
       - name: Deploy package
+        if: github.event_name == 'push'
         run: |
           git config --local user.email "actions@github.com"
           git config --local user.name "GitHub Actions"


### PR DESCRIPTION
This PR:

- updates the pkgdown action to `build_site()` on PRs
- adds back in the older R tests now that the new lava is on CRAN