### PR TITLE
Add id to initial_time_split()

### DIFF
--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -80,7 +80,13 @@ initial_time_split <- function(data, prop = 3/4, lag = 0, ...) {
     stop("`lag` must be less than or equal to the number of training observations.", call. = FALSE)
   }
 
-  rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))
+  res <- manual_rset(
+    splits = list(rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))),
+    ids = "Resample1"
+  )
+
+  res$splits[[1]]
+
 }
 
 #' @rdname initial_split

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -80,12 +80,12 @@ initial_time_split <- function(data, prop = 3/4, lag = 0, ...) {
     stop("`lag` must be less than or equal to the number of training observations.", call. = FALSE)
   }
 
-  res <- manual_rset(
-    splits = list(rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))),
-    ids = "Resample1"
-  )
+  split  <- rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))
+  splits <- list(split)
+  ids    <- "Resample1"
+  rset   <- new_rset(splits, ids)
 
-  res$splits[[1]]
+  rset$splits[[1]]
 
 }
 


### PR DESCRIPTION
Closes #175 

``` r
library(rsample)

split1 <- initial_split(mtcars)
split1$id
#> # A tibble: 1 x 1
#>   id       
#>   <chr>    
#> 1 Resample1

split2 <- initial_time_split(mtcars)
split2$id
#> # A tibble: 1 x 1
#>   id       
#>   <chr>    
#> 1 Resample1
```

<sup>Created on 2020-11-30 by the [reprex package](https://reprex.tidyverse.org) (v0.3.0.9001)</sup>

I don't know if we want to make this change as shown here with `manual_rset()`, or just by adding the `id` in by assignment. Thoughts?

(By the way, the problem with `last_fit()` as shown in the linked issue is no longer a problem as of the new tune release, even without the `id`.)