### PR TITLE
rsplit obj_sum changes for r-lib/pillar#240 as well as #214

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,7 @@
 
 * A few internal functions were exported so that `rsample`-adjacent packages can use the same underlying code. 
 
+* The `obj_sum()` method for `rsplit` objects was updated.
 
 # rsample 0.0.8
 

--- a/R/rsplit.R
+++ b/R/rsplit.R
@@ -139,7 +139,7 @@ obj_sum.rsplit <- function(x, ...) {
   else
     paste(length(x$out_id))
 
-  paste0("rsplit [",
+  paste0("split [",
          length(x$in_id), "/",
          out_char, "]")
 }

--- a/tests/testthat/print_test_output/obj_sum
+++ b/tests/testthat/print_test_output/obj_sum
@@ -1,0 +1,8 @@
+> set.seed(233)
+> print(validation_split(mtcars))
+# Validation Set Split (0.75/0.25)  
+# A tibble: 1 x 2
+  splits         id        
+  <list>         <chr>     
+1 <split [24/8]> validation
+

--- a/tests/testthat/test_rsplit.R
+++ b/tests/testthat/test_rsplit.R
@@ -51,6 +51,10 @@ test_that('print methods', {
     set.seed(233)
     print(validation_split(mtcars)$splits[[1]])
   })
+  verify_output(test_path("print_test_output", "obj_sum"), {
+    set.seed(233)
+    print(validation_split(mtcars))
+  })
 })
 
 


### PR DESCRIPTION
Prints "split" instead of "rsplit". 