### PR TITLE
PR related to issue #217.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* Fixed an issue with `mc_cv()`, `initial_split()`, and `validation_split()` where the `prop` argument was being used to first compute the assessment indices rather than the analysis indices. This could cause a minor inconsistency in the sizes of the generated analysis and assessment sets when compared against how `prop` is documented to function (#217, @issactoast).
+
 # rsample 0.0.9
 
 * New `rset_reconstruct()`, a developer tool to ease creation of new rset subclasses (#210).

--- a/R/mc.R
+++ b/R/mc.R
@@ -61,7 +61,7 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
 
   split_objs <-
     mc_splits(data = data,
-              prop = prop, # prop for train set
+              prop = prop,
               times = times,
               strata = strata,
               breaks = breaks)
@@ -81,9 +81,9 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
            subclass = c("mc_cv", "rset"))
 }
 
-# Get the indices of the analysis set from the assessment set
+# Get the indices of the assessment set from the analysis set
 mc_complement <- function(ind, n) {
-  list(analysis = ind, # ind for analysis
+  list(analysis = ind,
        assessment = setdiff(1:n, ind))
 }
 

--- a/R/mc.R
+++ b/R/mc.R
@@ -61,7 +61,7 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
 
   split_objs <-
     mc_splits(data = data,
-              prop = 1 - prop,
+              prop = prop, # prop for train set
               times = times,
               strata = strata,
               breaks = breaks)
@@ -83,8 +83,8 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
 
 # Get the indices of the analysis set from the assessment set
 mc_complement <- function(ind, n) {
-  list(analysis = setdiff(1:n, ind),
-       assessment = ind)
+  list(analysis = ind, # ind for analysis
+       assessment = setdiff(1:n, ind))
 }
 
 

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -35,7 +35,7 @@ validation_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
 
   split_objs <-
     mc_splits(data = data,
-              prop = prop, # prop for analysis
+              prop = prop,
               times = 1,
               strata = strata,
               breaks = breaks)

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -35,7 +35,7 @@ validation_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
 
   split_objs <-
     mc_splits(data = data,
-              prop = 1 - prop,
+              prop = prop, # prop for analysis
               times = 1,
               strata = strata,
               breaks = breaks)

--- a/tests/testthat/test_initial.R
+++ b/tests/testthat/test_initial.R
@@ -40,3 +40,25 @@ test_that('default time param with lag', {
   expect_error(initial_time_split(drinks, lag = 500))  # Lag must be less than number of training observations
 
 })
+
+test_that("`prop` computes the proportion for analysis (#217)", {
+  set.seed(11)
+
+  props <- c(.1, .9)
+
+  for (prop in props) {
+    # Not stratified
+    split <- initial_split(airquality, prop = prop)
+    actual <- nrow(analysis(split))
+    expect <- as.integer(floor(nrow(airquality) * prop))
+
+    expect_identical(actual, expect)
+
+    # Stratified
+    split <- initial_split(airquality, prop = prop, strata = Month)
+    actual <- nrow(analysis(split))
+    expect <- as.integer(sum(floor(table(airquality$Month) * prop)) )
+
+    expect_identical(actual, expect)
+  }
+})

--- a/tests/testthat/test_mc.R
+++ b/tests/testthat/test_mc.R
@@ -46,11 +46,13 @@ test_that('different percent', {
 
 test_that('strata', {
   set.seed(11)
+
   rs3 <- mc_cv(warpbreaks, strata = "tension")
   sizes3 <- dim_rset(rs3)
 
-  expect_true(all(sizes3$analysis == 42))
-  expect_true(all(sizes3$assessment == 12))
+  # sum(floor(table(warpbreaks$tension) * prop)) = 39
+  expect_true(all(sizes3$analysis == 39))
+  expect_true(all(sizes3$assessment == 15))
 
   rate <- map_dbl(rs3$splits,
                   function(x) {

--- a/tests/testthat/test_validation.R
+++ b/tests/testthat/test_validation.R
@@ -49,8 +49,8 @@ test_that('strata', {
   rs3 <- validation_split(warpbreaks, strata = "tension")
   sizes3 <- dim_rset(rs3)
 
-  expect_true(all(sizes3$analysis == 42))
-  expect_true(all(sizes3$assessment == 12))
+  expect_true(all(sizes3$analysis == 39))
+  expect_true(all(sizes3$assessment == 15))
 
   rate <- map_dbl(rs3$splits,
                   function(x) {


### PR DESCRIPTION
Hi @juliasilge 

This PR related to issue #217 

I have been thinking about this since I found `strat_sample` sounds good to me, so I fork the package and let my data flow the functions. 

I found two parts is switched which make the result different than `sample_frac` in `dplyr`

I twicked `mc_splits` input from 1-prop to prop, so that the functions in mc.R find the index for prop. And I finally use `ind` for the analysis. 

These two chance makes the result from rsample and dplyr to be the same as follows;

``` r
#sample_frac and sample_n
library(dplyr)

set.seed(2021)
dim(airquality)
#> [1] 153   6

#sample 10% from each month
airquality_frac <- airquality %>% 
  group_by(Month) %>%  
  sample_frac(size = 0.1, replace=FALSE)

library(rsample)

airquality_split <- initial_split(airquality, prop = 0.1,
                                  strata = "Month")

airquality_frac2 <- training(airquality_split)

dim(airquality_frac)
#> [1] 15  6
dim(airquality_frac2)
#> [1] 15  6
```

Could you give me a feedback? I have feeling that this resolves the issue (user expectation about prop input) and increases the coherence between the tidymodels and the tidyverse packages. What do you think?