### PR TITLE
Create apparent() via new_rset()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* Fixed problem with creation of `apparent()` samples.
+
 # rsample 0.0.9
 
 * New `rset_reconstruct()`, a developer tool to ease creation of new rset subclasses (#210).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rsample (development version)
 
-* Fixed problem with creation of `apparent()` samples.
+* Fixed problem with creation of `apparent()` samples (#223).
 
 # rsample 0.0.9
 

--- a/R/apparent.R
+++ b/R/apparent.R
@@ -22,11 +22,10 @@ apparent <- function(data, ...) {
   class(splits) <- c("rsplit", "apparent_split")
   split_objs <- tibble::tibble(splits = list(splits), id = "Apparent")
 
-  split_objs <-
-    add_class(split_objs,
-              cls = c("apparent", "rset"))
-
-  split_objs
+  new_rset(splits = split_objs$splits,
+           ids = split_objs$id,
+           attrib = NULL,
+           subclass = c("apparent", "rset"))
 }
 
 #' @export


### PR DESCRIPTION
This PR closes #190 by creating an `apparent()` resample via `new_rset()`, which means there is now a label:

``` r
library(rsample)

car_samp <- apparent(mtcars)
split1 <- car_samp$splits[[1]]
labels(split1)
#> # A tibble: 1 x 1
#>   id      
#>   <chr>   
#> 1 Apparent
```

<sup>Created on 2021-02-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>

This means that tuning/etc now works:

``` r
library(tidymodels)

set.seed(234)
workflow() %>%
  add_model(linear_reg() %>% set_engine("lm")) %>%
  add_recipe(recipe(mpg ~ hp, data = mtcars)) %>%
  tune_grid(resamples = apparent(mtcars))
#> Warning: No tuning parameters have been detected, performance will be evaluated
#> using the resamples with no tuning. Did you want to [tune()] parameters?
#> # Tuning results
#> # Apparent sampling 
#> # A tibble: 1 x 4
#>   splits          id       .metrics         .notes          
#>   <list>          <chr>    <list>           <list>          
#> 1 <split [32/32]> Apparent <tibble [2 × 4]> <tibble [0 × 1]>
```

<sup>Created on 2021-02-19 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>