### PR TITLE
Expose `pool` argument across resampling functions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,5 +42,5 @@ License: MIT + file LICENSE
 Encoding: UTF-8
 VignetteBuilder: knitr
 LazyData: true
-RoxygenNote: 7.1.1.9000
+RoxygenNote: 7.1.1.9001
 Roxygen: list(markdown = TRUE)

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,7 @@
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/rsample/issues/226).
 
+* Exposed `pool` argument from `make_strata()` in user-facing resampling functions (#229).
 
 # rsample 0.0.9
 

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -9,12 +9,11 @@
 #'  of data points in the training data is equivalent to the proportions in the
 #'  original data set. (Strata below 10% of the total are pooled together.)
 #' @inheritParams vfold_cv
+#' @inheritParams make_strata
 #' @param prop The proportion of data to be retained for modeling/analysis.
 #' @param strata A variable that is used to conduct stratified sampling to
 #'  create the resamples. This could be a single character value or a variable
 #'  name that corresponds to a variable that exists in the data frame.
-#' @param breaks A single number giving the number of bins desired to stratify
-#'  a numeric stratification variable.
 #' @export
 #' @return An `rsplit` object that can be used with the `training` and `testing`
 #'  functions to extract the data in each split.
@@ -38,7 +37,8 @@
 #'
 #' @export
 #'
-initial_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
+initial_split <- function(data, prop = 3/4,
+                          strata = NULL, breaks = 4, pool = 0.1, ...) {
 
   if (!missing(strata)) {
     strata <- tidyselect::vars_select(names(data), !!enquo(strata))
@@ -53,6 +53,7 @@ initial_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
       prop = prop,
       strata = strata,
       breaks = breaks,
+      pool = pool,
       times = 1,
       ...
     )

--- a/R/mc.R
+++ b/R/mc.R
@@ -6,15 +6,15 @@
 #' @details The `strata` argument causes the random sampling to be conducted
 #'  *within the stratification variable*. This can help ensure that the number of
 #'  data points in the analysis data is equivalent to the proportions in the
-#'  original data set. (Strata below 10% of the total are pooled together.)
+#'  original data set. (Strata below 10% of the total are pooled together
+#'  by default.)
 #' @inheritParams vfold_cv
+#' @inheritParams make_strata
 #' @param prop The proportion of data to be retained for modeling/analysis.
 #' @param times The number of times to repeat the sampling.
 #' @param strata A variable that is used to conduct stratified sampling to
 #'  create the resamples. This could be a single character value or a variable
 #'  name that corresponds to a variable that exists in the data frame.
-#' @param breaks A single number giving the number of bins desired to stratify
-#'  a numeric stratification variable.
 #' @export
 #' @return An tibble with classes `mc_cv`, `rset`, `tbl_df`, `tbl`, and
 #'  `data.frame`. The results include a column for the data split objects and a
@@ -35,7 +35,7 @@
 #'         })
 #'
 #' set.seed(13)
-#' resample2 <- mc_cv(wa_churn, strata = "churn", times = 3, prop = .5)
+#' resample2 <- mc_cv(wa_churn, strata = churn, times = 3, prop = .5)
 #' map_dbl(resample2$splits,
 #'         function(x) {
 #'           dat <- as.data.frame(x)$churn
@@ -43,14 +43,15 @@
 #'         })
 #'
 #' set.seed(13)
-#' resample3 <- mc_cv(wa_churn, strata = "tenure", breaks = 6, times = 3, prop = .5)
+#' resample3 <- mc_cv(wa_churn, strata = tenure, breaks = 6, times = 3, prop = .5)
 #' map_dbl(resample3$splits,
 #'         function(x) {
 #'           dat <- as.data.frame(x)$churn
 #'           mean(dat == "Yes")
 #'         })
 #' @export
-mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) {
+mc_cv <- function(data, prop = 3/4, times = 25,
+                  strata = NULL, breaks = 4, pool = 0.1, ...) {
 
   if(!missing(strata)) {
     strata <- tidyselect::vars_select(names(data), !!enquo(strata))
@@ -64,7 +65,8 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
               prop = prop,
               times = times,
               strata = strata,
-              breaks = breaks)
+              breaks = breaks,
+              pool = pool)
 
   ## We remove the holdout indices since it will save space and we can
   ## derive them later when they are needed.
@@ -88,7 +90,9 @@ mc_complement <- function(ind, n) {
 }
 
 
-mc_splits <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4) {
+mc_splits <- function(data, prop = 3/4, times = 25,
+                      strata = NULL, breaks = 4, pool = 0.1) {
+
   if (!is.numeric(prop) | prop >= 1 | prop <= 0)
     stop("`prop` must be a number on (0, 1).", call. = FALSE)
 
@@ -98,7 +102,8 @@ mc_splits <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4) {
   } else {
     stratas <- tibble::tibble(idx = 1:n,
                               strata = make_strata(getElement(data, strata),
-                                                   breaks = breaks))
+                                                   breaks = breaks,
+                                                   pool = pool))
     stratas <- split_unnamed(stratas, stratas$strata)
     stratas <-
       purrr::map_df(stratas, strat_sample, prop = prop, times = times)

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -8,12 +8,11 @@
 #'  data points in the analysis data is equivalent to the proportions in the
 #'  original data set. (Strata below 10% of the total are pooled together.)
 #' @inheritParams vfold_cv
+#' @inheritParams make_strata
 #' @param prop The proportion of data to be retained for modeling/analysis.
 #' @param strata A variable that is used to conduct stratified sampling to
 #'  create the resamples. This could be a single character value or a variable
 #'  name that corresponds to a variable that exists in the data frame.
-#' @param breaks A single number giving the number of bins desired to stratify
-#'  a numeric stratification variable.
 #' @export
 #' @return An tibble with classes `validation_split`, `rset`, `tbl_df`, `tbl`,
 #'  and `data.frame`. The results include a column for the data split objects
@@ -22,7 +21,8 @@
 #' @examples
 #' validation_split(mtcars, prop = .9)
 #' @export
-validation_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
+validation_split <- function(data, prop = 3/4,
+                             strata = NULL, breaks = 4, pool = 0.1, ...) {
 
   if (!missing(strata)) {
     strata <- tidyselect::vars_select(names(data), !!enquo(strata))
@@ -38,7 +38,8 @@ validation_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
               prop = prop,
               times = 1,
               strata = strata,
-              breaks = breaks)
+              breaks = breaks,
+              pool = pool)
 
   ## We remove the holdout indices since it will save space and we can
   ## derive them later when they are needed.

--- a/man/bootstraps.Rd
+++ b/man/bootstraps.Rd
@@ -4,7 +4,15 @@
 \alias{bootstraps}
 \title{Bootstrap Sampling}
 \usage{
-bootstraps(data, times = 25, strata = NULL, breaks = 4, apparent = FALSE, ...)
+bootstraps(
+  data,
+  times = 25,
+  strata = NULL,
+  breaks = 4,
+  pool = 0.1,
+  apparent = FALSE,
+  ...
+)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -16,8 +24,13 @@ not \code{NULL}, each bootstrap sample is created within the stratification
 variable. This could be a single character value or a variable name that
 corresponds to a variable that exists in the data frame.}
 
-\item{breaks}{A single number giving the number of bins desired to stratify
-a numeric stratification variable.}
+\item{breaks}{A single number giving the number of bins desired to stratify a
+numeric stratification variable.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{apparent}{A logical. Should an extra resample be added where the
 analysis and holdout subset are the entire data set. This is required for
@@ -48,7 +61,7 @@ The \code{strata} argument is based on a similar argument in the random forest
 package were the bootstrap samples are conducted \emph{within the stratification
 variable}. This can help ensure that the number of data points in the
 bootstrap sample is equivalent to the proportions in the original data set.
-(Strata below 10\% of the total are pooled together.)
+(Strata below 10\% of the total are pooled together by default.)
 }
 \examples{
 bootstraps(mtcars, times = 2)
@@ -67,7 +80,7 @@ map_dbl(resample1$splits,
         })
 
 set.seed(13)
-resample2 <- bootstraps(wa_churn, strata = "churn", times = 3)
+resample2 <- bootstraps(wa_churn, strata = churn, times = 3)
 map_dbl(resample2$splits,
         function(x) {
           dat <- as.data.frame(x)$churn
@@ -75,7 +88,7 @@ map_dbl(resample2$splits,
         })
 
 set.seed(13)
-resample3 <- bootstraps(wa_churn, strata = "tenure", breaks = 6, times = 3)
+resample3 <- bootstraps(wa_churn, strata = tenure, breaks = 6, times = 3)
 map_dbl(resample3$splits,
         function(x) {
           dat <- as.data.frame(x)$churn

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -7,7 +7,7 @@
 \alias{testing}
 \title{Simple Training/Test Set Splitting}
 \usage{
-initial_split(data, prop = 3/4, strata = NULL, breaks = 4, ...)
+initial_split(data, prop = 3/4, strata = NULL, breaks = 4, pool = 0.1, ...)
 
 initial_time_split(data, prop = 3/4, lag = 0, ...)
 
@@ -24,8 +24,13 @@ testing(x)
 create the resamples. This could be a single character value or a variable
 name that corresponds to a variable that exists in the data frame.}
 
-\item{breaks}{A single number giving the number of bins desired to stratify
-a numeric stratification variable.}
+\item{breaks}{A single number giving the number of bins desired to stratify a
+numeric stratification variable.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{...}{Not currently used.}
 

--- a/man/make_strata.Rd
+++ b/man/make_strata.Rd
@@ -16,7 +16,9 @@ numeric stratification variable.}
 algorithm.}
 
 \item{pool}{A proportion of data used to determine if a particular group is
-too small and should be pooled into another group.}
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{depth}{An integer that is used to determine the best number of
 percentiles that should be used. The number of bins are based on

--- a/man/mc_cv.Rd
+++ b/man/mc_cv.Rd
@@ -4,7 +4,7 @@
 \alias{mc_cv}
 \title{Monte Carlo Cross-Validation}
 \usage{
-mc_cv(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...)
+mc_cv(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, pool = 0.1, ...)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -17,8 +17,13 @@ mc_cv(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...)
 create the resamples. This could be a single character value or a variable
 name that corresponds to a variable that exists in the data frame.}
 
-\item{breaks}{A single number giving the number of bins desired to stratify
-a numeric stratification variable.}
+\item{breaks}{A single number giving the number of bins desired to stratify a
+numeric stratification variable.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{...}{Not currently used.}
 }
@@ -36,7 +41,8 @@ data points are added to the assessment set.
 The \code{strata} argument causes the random sampling to be conducted
 \emph{within the stratification variable}. This can help ensure that the number of
 data points in the analysis data is equivalent to the proportions in the
-original data set. (Strata below 10\% of the total are pooled together.)
+original data set. (Strata below 10\% of the total are pooled together
+by default.)
 }
 \examples{
 mc_cv(mtcars, times = 2)
@@ -54,7 +60,7 @@ map_dbl(resample1$splits,
         })
 
 set.seed(13)
-resample2 <- mc_cv(wa_churn, strata = "churn", times = 3, prop = .5)
+resample2 <- mc_cv(wa_churn, strata = churn, times = 3, prop = .5)
 map_dbl(resample2$splits,
         function(x) {
           dat <- as.data.frame(x)$churn
@@ -62,7 +68,7 @@ map_dbl(resample2$splits,
         })
 
 set.seed(13)
-resample3 <- mc_cv(wa_churn, strata = "tenure", breaks = 6, times = 3, prop = .5)
+resample3 <- mc_cv(wa_churn, strata = tenure, breaks = 6, times = 3, prop = .5)
 map_dbl(resample3$splits,
         function(x) {
           dat <- as.data.frame(x)$churn

--- a/man/validation_split.Rd
+++ b/man/validation_split.Rd
@@ -4,7 +4,7 @@
 \alias{validation_split}
 \title{Create a Validation Set}
 \usage{
-validation_split(data, prop = 3/4, strata = NULL, breaks = 4, ...)
+validation_split(data, prop = 3/4, strata = NULL, breaks = 4, pool = 0.1, ...)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -15,8 +15,13 @@ validation_split(data, prop = 3/4, strata = NULL, breaks = 4, ...)
 create the resamples. This could be a single character value or a variable
 name that corresponds to a variable that exists in the data frame.}
 
-\item{breaks}{A single number giving the number of bins desired to stratify
-a numeric stratification variable.}
+\item{breaks}{A single number giving the number of bins desired to stratify a
+numeric stratification variable.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{...}{Not currently used.}
 }

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -4,7 +4,7 @@
 \alias{vfold_cv}
 \title{V-Fold Cross-Validation}
 \usage{
-vfold_cv(data, v = 10, repeats = 1, strata = NULL, breaks = 4, ...)
+vfold_cv(data, v = 10, repeats = 1, strata = NULL, breaks = 4, pool = 0.1, ...)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -17,8 +17,13 @@ vfold_cv(data, v = 10, repeats = 1, strata = NULL, breaks = 4, ...)
 create the folds. This could be a single character value or a variable name
 that corresponds to a variable that exists in the data frame.}
 
-\item{breaks}{A single number giving the number of bins desired to stratify
-a numeric stratification variable.}
+\item{breaks}{A single number giving the number of bins desired to stratify a
+numeric stratification variable.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 
 \item{...}{Not currently used.}
 }
@@ -41,7 +46,7 @@ to V.
 The \code{strata} argument causes the random sampling to be conducted \emph{within
 the stratification variable}. This can help ensure that the number of data
 points in the analysis data is equivalent to the proportions in the original
-data set. (Strata below 10\% of the total are pooled together.)
+data set. (Strata below 10\% of the total are pooled together by default.)
 When more than one repeat is requested, the basic V-fold cross-validation
 is conducted each time. For example, if three repeats are used with \code{v = 10}, there are a total of 30 splits which as three groups of 10 that are
 generated separately.
@@ -62,7 +67,7 @@ map_dbl(folds1$splits,
         })
 
 set.seed(13)
-folds2 <- vfold_cv(wa_churn, strata = "churn", v = 5)
+folds2 <- vfold_cv(wa_churn, strata = churn, v = 5)
 map_dbl(folds2$splits,
         function(x) {
           dat <- as.data.frame(x)$churn
@@ -70,7 +75,7 @@ map_dbl(folds2$splits,
         })
 
 set.seed(13)
-folds3 <- vfold_cv(wa_churn, strata = "tenure", breaks = 6, v = 5)
+folds3 <- vfold_cv(wa_churn, strata = tenure, breaks = 6, v = 5)
 map_dbl(folds3$splits,
         function(x) {
           dat <- as.data.frame(x)$churn

--- a/tests/testthat/test_strata.R
+++ b/tests/testthat/test_strata.R
@@ -17,14 +17,20 @@ test_that('simple numerics', {
 })
 
 test_that('simple character', {
-  x2 <- factor(rep(LETTERS[1:5], each = 50))
-  str2a <- make_strata(x2)
+  x2 <- factor(rep(LETTERS[1:12], each = 20))
+  expect_warning(
+    str2a <- make_strata(x2, pool = 0.05),
+    "Stratifying groups that make up 5%"
+  )
   expect_equal(table(str2a, dnn = ""), table(x2, dnn = ""))
+
 })
 
 test_that('bad data', {
   x3 <- factor(rep(LETTERS[1:15], each = 50))
-  expect_warning(make_strata(x3))
+  expect_warning(make_strata(x3), "Too little data")
+  expect_warning(make_strata(x3, pool = 0.06),
+                 "Stratifying groups that make up 6%")
   expect_warning(make_strata(mtcars$mpg))
 })
 

--- a/tests/testthat/test_vfold.R
+++ b/tests/testthat/test_vfold.R
@@ -66,6 +66,12 @@ test_that('strata', {
                             length(intersect(x$in_ind, x$out_id)) == 0
                           })
   expect_true(all(good_holdout))
+
+  expect_warning(
+    rs4 <- vfold_cv(mlc_churn, strata = state, pool = 0.01),
+    "Stratifying groups that make up 1%"
+  )
+
 })
 
 


### PR DESCRIPTION
This PR closes #211 by exposing the `pool` argument to user-facing functions such as `vfold_cv()`, `mc_cv()`, and `bootstraps()`.

``` r
library(tidyverse)
library(rsample)

df <- tibble(x = rnorm(60), label = rep(letters[1:12], each = 5))

mc_cv(df, v = 3, strata = label)
#> Warning: Too little data to stratify. Unstratified resampling
#> # Monte Carlo cross-validation (0.75/0.25) with 25 resamples  using stratification 
#> # A tibble: 25 x 2
#>    splits          id        
#>    <list>          <chr>     
#>  1 <split [45/15]> Resample01
#>  2 <split [45/15]> Resample02
#>  3 <split [45/15]> Resample03
#>  4 <split [45/15]> Resample04
#>  5 <split [45/15]> Resample05
#>  6 <split [45/15]> Resample06
#>  7 <split [45/15]> Resample07
#>  8 <split [45/15]> Resample08
#>  9 <split [45/15]> Resample09
#> 10 <split [45/15]> Resample10
#> # … with 15 more rows
mc_cv(df, v = 3, strata = label, pool = 0.05)
#> Warning: Stratifying groups that make up 5% of the data may be statistically risky.
#> Consider increasing `pool` to at least 0.1
#> # Monte Carlo cross-validation (0.75/0.25) with 25 resamples  using stratification 
#> # A tibble: 25 x 2
#>    splits          id        
#>    <list>          <chr>     
#>  1 <split [36/24]> Resample01
#>  2 <split [36/24]> Resample02
#>  3 <split [36/24]> Resample03
#>  4 <split [36/24]> Resample04
#>  5 <split [36/24]> Resample05
#>  6 <split [36/24]> Resample06
#>  7 <split [36/24]> Resample07
#>  8 <split [36/24]> Resample08
#>  9 <split [36/24]> Resample09
#> 10 <split [36/24]> Resample10
#> # … with 15 more rows
```

<sup>Created on 2021-03-09 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>