### PR TITLE
Attempts to stratify on `Surv` objects error more informatively

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,7 @@
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/rsample/issues/226).
 
-* Attempts to stratify on a `Surv` object now error more informatively. (#230)
+* Attempts to stratify on a `Surv` object now error more informatively (#230). 
 
 
 # rsample 0.0.9

--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,8 @@
 
 * Re-licensed package from GPL-2 to MIT. See [consent from copyright holders here](https://github.com/tidymodels/rsample/issues/226).
 
+* Attempts to stratify on a `Surv` object now error more informatively. (#230)
+
 
 # rsample 0.0.9
 

--- a/R/boot.R
+++ b/R/boot.R
@@ -76,7 +76,7 @@ bootstraps <-
     if(length(strata) == 0) strata <- NULL
   }
 
-  strata_check(strata, names(data))
+  strata_check(strata, data)
 
   split_objs <-
     boot_splits(

--- a/R/mc.R
+++ b/R/mc.R
@@ -57,7 +57,7 @@ mc_cv <- function(data, prop = 3/4, times = 25, strata = NULL, breaks = 4, ...) 
     if(length(strata) == 0) strata <- NULL
   }
 
-  strata_check(strata, names(data))
+  strata_check(strata, data)
 
   split_objs <-
     mc_splits(data = data,

--- a/R/misc.R
+++ b/R/misc.R
@@ -38,12 +38,15 @@ add_class <- function(x, cls) {
   x
 }
 
-strata_check <- function(strata, vars) {
+strata_check <- function(strata, data) {
   if (!is.null(strata)) {
     if (!is.character(strata) | length(strata) != 1) {
       rlang::abort("`strata` should be a single character value.")
     }
-    if (!(strata %in% vars)) {
+    if (inherits(data[, strata], "Surv")) {
+      rlang::abort("`strata` cannot be a `Surv` object. Use the time or event indicator directly.")
+    }
+    if (!(strata %in% names(data))) {
       rlang::abort(strata, " is not in `data`.")
     }
   }

--- a/R/misc.R
+++ b/R/misc.R
@@ -44,7 +44,7 @@ strata_check <- function(strata, data) {
       rlang::abort("`strata` should be a single character value.")
     }
     if (inherits(data[, strata], "Surv")) {
-      rlang::abort("`strata` cannot be a `Surv` object. Use the time or event indicator directly.")
+      rlang::abort("`strata` cannot be a `Surv` object. Use the time or event variable directly.")
     }
     if (!(strata %in% names(data))) {
       rlang::abort(strata, " is not in `data`.")

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -31,7 +31,7 @@ validation_split <- function(data, prop = 3/4, strata = NULL, breaks = 4, ...) {
     }
   }
 
-  strata_check(strata, names(data))
+  strata_check(strata, data)
 
   split_objs <-
     mc_splits(data = data,

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -69,7 +69,7 @@ vfold_cv <- function(data, v = 10, repeats = 1, strata = NULL, breaks = 4, ...) 
     if(length(strata) == 0) strata <- NULL
   }
 
-  strata_check(strata, names(data))
+  strata_check(strata, data)
 
   if (repeats == 1) {
     split_objs <- vfold_splits(data = data, v = v, strata = strata, breaks = breaks)

--- a/tests/testthat/test_strata.R
+++ b/tests/testthat/test_strata.R
@@ -30,3 +30,20 @@ test_that('bad data', {
 
 
 
+# strata_check() ----------------------------------------------------------
+
+test_that("don't stratify on Surv objects", {
+  df <- data.frame(
+    time = c(85, 79, 70, 6, 32, 8, 17, 93, 81, 76),
+    event = c(0, 0, 1, 0, 0, 0, 1, 1, 1, 1)
+  )
+  df$surv <- structure(
+    c(85, 79, 70, 6, 32, 8, 17, 93, 81, 76,
+      0, 0, 1, 0, 0, 0, 1, 1, 1, 1),
+    .Dim = c(10L, 2L),
+    .Dimnames = list(NULL, c("time", "status")),
+    type = "right",
+    class = "Surv")
+
+  expect_error(strata_check("surv", df))
+})


### PR DESCRIPTION
Closes #230 

``` r
library(rsample)
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(survival)
data("lung")

lung %>% 
  mutate(surv = Surv(time, status)) %>% 
  initial_split(strata = "surv")
#> Error: `strata` cannot be a `Surv` object. Use the time or event indicator directly.
```

<sup>Created on 2021-03-16 by the [reprex package](https://reprex.tidyverse.org) (v1.0.0)</sup>