### PR TITLE
Create `caret2rsample()` via `new_rset()`

### DIFF
--- a/R/caret.R
+++ b/R/caret.R
@@ -13,7 +13,7 @@
 rsample2caret <- function(object, data = c("analysis", "assessment")) {
   if(!inherits(object, "rset"))
     stop("`object` must be an `rset`", call. = FALSE)
-  data <- match.arg(data)
+  data <- rlang::arg_match(data)
   in_ind <- purrr::map(object$splits, as.integer, data = "analysis")
   names(in_ind) <- labels(object)
   out_ind <- purrr::map(object$splits, as.integer, data = "assessment")
@@ -59,12 +59,12 @@ caret2rsample <- function(ctrl, data = NULL) {
   } else {
     id_data <- tibble::tibble(id = id_data)
   }
-  out <- dplyr::bind_cols(indices, id_data)
-  attrib <- map_attr(ctrl)
-  for (i in names(attrib))
-    attr(out, i) <- attrib[[i]]
-  out <- add_rset_class(out, map_rset_method(ctrl$method))
-  out
+
+  new_rset(splits = indices$splits,
+           ids = id_data[, grepl("^id", names(id_data))],
+           attrib = map_attr(ctrl),
+           subclass = c(map_rset_method(ctrl$method), "rset"))
+
 }
 
 extract_int <- function(x, y)


### PR DESCRIPTION
Closes #147 

This PR creates the `caret2rsample()` objects via `new_rset()`, which means that tuning now works:

``` r
library(caret)
#> Loading required package: lattice
#> Loading required package: ggplot2
library(tidymodels)
#> Registered S3 method overwritten by 'tune':
#>   method                   from   
#>   required_pkgs.model_spec parsnip


cvTrain <- trainControl(method = "cv", number = 5,
                        index = list(Fold1 = 10001:4e4, 
                                     Fold2 = c(1:1e4, 20001:4e4), 
                                     Fold3 = c(1:2e4, 30001:4e4), 
                                     Fold4 = 1:3e4),
                        indexOut = list(Fold1 = 1:1e4, 
                                        Fold2 = 10001:2e4,
                                        Fold3 = 20001:3e4,
                                        Fold4 = 30001:4e4))

diamond_folds <- caret2rsample(cvTrain, diamonds[1:4e4,])
diamond_folds
#> #  5-fold cross-validation using stratification 
#> # A tibble: 4 x 2
#>   splits                id   
#>   <list>                <chr>
#> 1 <split [30000/10000]> Fold1
#> 2 <split [30000/10000]> Fold2
#> 3 <split [30000/10000]> Fold3
#> 4 <split [30000/10000]> Fold4

linear_reg(penalty = tune(), mixture = 1) %>% 
  set_engine("glmnet") %>%
  tune_grid(
    price ~ .,
    resamples = diamond_folds,
    grid = 5
  )
#> # Tuning results
#> # 5-fold cross-validation using stratification 
#> # A tibble: 4 x 4
#>   splits                id    .metrics              .notes              
#>   <list>                <chr> <list>                <list>              
#> 1 <split [30000/10000]> Fold1 <tibble[,5] [10 × 5]> <tibble[,1] [0 × 1]>
#> 2 <split [30000/10000]> Fold2 <tibble[,5] [10 × 5]> <tibble[,1] [0 × 1]>
#> 3 <split [30000/10000]> Fold3 <tibble[,5] [10 × 5]> <tibble[,1] [0 × 1]>
#> 4 <split [30000/10000]> Fold4 <tibble[,5] [10 × 5]> <tibble[,1] [0 × 1]>
```

<sup>Created on 2021-04-07 by the [reprex package](https://reprex.tidyverse.org) (v2.0.0)</sup>