### PR TITLE
Exclude NAs from percentile calculation in make_strata()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,8 @@
 
 * Deprecated the `gather()` method for `rset` objects in favor of `tidyr::pivot_longer()` (#233).
 
+* Fixed bug in `make_strata()` for numeric variables with `NA` values (@brian-j-smith, #236).
+
 # rsample 0.0.9
 
 * New `rset_reconstruct()`, a developer tool to ease creation of new rset subclasses (#210).

--- a/R/make_strata.R
+++ b/R/make_strata.R
@@ -113,7 +113,7 @@ make_strata <- function(x, breaks = 4, nunique = 5, pool = .1, depth = 20) {
                   "will be used.")
       return(factor(rep("strata1", n)))
     }
-    pctls <- quantile(x, probs = (0:breaks) / breaks)
+    pctls <- quantile(x, probs = (0:breaks) / breaks, na.rm = TRUE)
     pctls <- unique(pctls)
     out <- cut(x, breaks = pctls, include.lowest = TRUE)
   }

--- a/R/make_strata.R
+++ b/R/make_strata.R
@@ -71,7 +71,7 @@
 make_strata <- function(x, breaks = 4, nunique = 5, pool = .1, depth = 20) {
 
   default_pool <- 0.1
-  num_vals <- unique(x)
+  num_vals <- unique(na.omit(x))
   n <- length(x)
   if (length(num_vals) <= nunique | is.character(x) | is.factor(x)) {
     x <- factor(x)

--- a/R/make_strata.R
+++ b/R/make_strata.R
@@ -73,7 +73,6 @@ make_strata <- function(x, breaks = 4, nunique = 5, pool = .1, depth = 20) {
   default_pool <- 0.1
   num_vals <- unique(x)
   n <- length(x)
-  num_miss <- sum(is.na(x))
   if (length(num_vals) <= nunique | is.character(x) | is.factor(x)) {
     x <- factor(x)
     xtab <- sort(table(x))

--- a/tests/testthat/test_strata.R
+++ b/tests/testthat/test_strata.R
@@ -14,6 +14,11 @@ test_that('simple numerics', {
   str1b <- expect_warning(make_strata(x1, depth = 500), "2 breaks instead")
   tab1b <- table(str1b)
   expect_equal(as.vector(tab1b), rep(500, 2))
+
+  str1c <- make_strata(c(NA, x1[1:999]))
+  tab1c <- table(str1c)
+  expect_true(all(as.vector(tab1c) %in% 249:251))
+
 })
 
 test_that('simple character', {
@@ -23,6 +28,14 @@ test_that('simple character', {
     "Stratifying groups that make up 5%"
   )
   expect_equal(table(str2a, dnn = ""), table(x2, dnn = ""))
+
+
+  x2[5] <- NA
+  expect_warning(
+    str2b <- make_strata(x2, pool = 0.05),
+    "Stratifying groups that make up 5%"
+  )
+  expect_true(all(as.vector(table(str2b, dnn = "")) %in% 19:21))
 
 })
 


### PR DESCRIPTION
This is a fix for an error returned by make_strata() when trying to create percentiles from numeric data that contain missing values.  The code below will reproduce the error.

```r
library(rsample)
make_strata(c(NA, 1:100))
```