### PR TITLE
Escalate deprecation for `gather.rset`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Change `make_splits()` to an S3 generic, with the original functionality a method for `list` and a new method for dataframes that allows users to create a split from existing analysis & assessment sets (@LiamBlake, #246).
 
+* Escalated the deprecation of the `gather()` method for `rset` objects to a hard deprecation. Use `tidyr::pivot_longer()` instead (#257).
+
 # rsample 0.1.0
 
 * Fixed how `mc_cv()`, `initial_split()`, and `validation_split()` use the `prop` argument to first compute the assessment indices, rather than the analysis indices. This is a minor but **breaking change** in some situations; the previous implementation could cause an inconsistency in the sizes of the generated analysis and assessment sets when compared to how `prop` is documented to function (#217, @issactoast).

--- a/R/gather.R
+++ b/R/gather.R
@@ -48,7 +48,7 @@
 gather.rset <- function(data, key = NULL, value = NULL, ..., na.rm = TRUE,
                         convert = FALSE, factor_key = TRUE) {
 
-  lifecycle::deprecate_warn("0.1.0", "gather.rset()", "tidyr::pivot_longer()")
+  lifecycle::deprecate_stop("0.1.0", "gather.rset()", "tidyr::pivot_longer()")
 
   if (any(names(data) == "splits")) {
     data <- data %>% dplyr::select(-splits)


### PR DESCRIPTION
This PR escalates the deprecation of the `gather` method for rset objects. Related to #233.