### PR TITLE
Support variables in args for `nested_cv()` call objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* Fixed how `nested_cv()` handles call objects so variables in the environment can be used when specifying resampling schemes (#81).
+
 # rsample 0.1.1
 
 * Updated documentation on stratified sampling (#245).

--- a/R/nest.R
+++ b/R/nest.R
@@ -48,6 +48,7 @@
 #' @export
 nested_cv <- function(data, outside, inside)  {
   cl <- match.call()
+  env <- rlang::caller_env()
 
   boot_msg <-
     paste0(
@@ -59,9 +60,9 @@ nested_cv <- function(data, outside, inside)  {
   outer_cl <- cl[["outside"]]
   if (is_call(outer_cl)) {
     if (grepl("^bootstraps", deparse(outer_cl)))
-      rlang::warn(boot_msg)
+      warn(boot_msg)
     outer_cl <- rlang::call_modify(outer_cl, data = data)
-    outside <- rlang::eval_tidy(outer_cl, env = rlang::caller_env())
+    outside <- eval(outer_cl, env)
   } else {
     if (inherits(outside, "bootstraps"))
       warn(boot_msg)
@@ -73,21 +74,19 @@ nested_cv <- function(data, outside, inside)  {
       "`inside` should be a expression such as `vfold()` or ",
       "bootstraps(times = 10)` instead of an existing object.",
     )
-  inside <- map(outside$splits, inside_resample, cl = inner_cl)
-  inside <- map(inside, rlang::eval_tidy, env = rlang::caller_env())
+  inside <- map(outside$splits, inside_resample, cl = inner_cl, env = env)
 
   out <- dplyr::mutate(outside, inner_resamples = inside)
-
   out <- add_class(out, cls = "nested_cv")
-
   attr(out, "outside") <- cl$outside
   attr(out, "inside") <- cl$inside
 
   out
 }
 
-inside_resample <- function(src, cl) {
-  rlang::call_modify(cl, data = as.data.frame(src))
+inside_resample <- function(src, cl, env) {
+  cl <- rlang::call_modify(cl, data = as.data.frame(src))
+  eval(cl, envir = env)
 }
 
 #' @export

--- a/tests/testthat/test_nesting.R
+++ b/tests/testthat/test_nesting.R
@@ -55,6 +55,23 @@ test_that('bad args', {
   )
 })
 
+test_that('can pass in variables', {
+
+  make_folds <- function(df) {
+    outer_cv <- 5
+    inner_cv <- 4
+    nested_cv(df,
+              outside = vfold_cv(v = outer_cv),
+              inside = vfold_cv(v = inner_cv))
+  }
+
+  rs1 <- make_folds(mtcars[1:30,])
+  sizes1 <- dim_rset(rs1)
+  expect_true(all(sizes1$analysis == 24))
+  expect_true(all(sizes1$assessment == 6))
+
+})
+
 test_that('printing', {
   rs1 <- nested_cv(mtcars[1:30,],
                    outside = vfold_cv(v = 10),


### PR DESCRIPTION
Closes #81 


I spent some time today working on this (very old) issue and I _think_ this is the best solution. In the example shared, the values such as `outer_cv <- 5` are not in the call but in the calling environment.

One thing that confuses me a bit is that the *default* for `eval_tidy()` is `rlang::caller_env()` but if I don't explicitly set it like I do here, we still can't find those values.

Anyway here is what we get now:

``` r
library(dplyr)
#> 
#> Attaching package: 'dplyr'
#> The following objects are masked from 'package:stats':
#> 
#>     filter, lag
#> The following objects are masked from 'package:base':
#> 
#>     intersect, setdiff, setequal, union
library(rsample)

run_experiment <- function(all_dataset) {
  outer_cv <- 5
  inner_cv <- 4
  sampling1 <- nested_cv(all_dataset,
                         outside = group_vfold_cv(v = outer_cv, group = "Rep"),
                         inside = group_vfold_cv(v = inner_cv, group = "Rep"))
  
  sampling2 <- nested_cv(all_dataset,
                         outside = group_vfold_cv(v = outer_cv, group = "Rep2"),
                         inside = group_vfold_cv(v = inner_cv, group = "Rep2"))
  
  list(sampling1, sampling2)
}

all_dataset <- matrix(nrow = 50, ncol = 5, 0) %>% as.data.frame()
all_dataset$Rep <- 1:5
all_dataset$Rep2 <- 5:1
run_experiment(tibble(all_dataset))
#> [[1]]
#> # Nested resampling:
#> #  outer: Group 5-fold cross-validation
#> #  inner: Group 4-fold cross-validation
#> # A tibble: 5 × 3
#>   splits          id        inner_resamples         
#>   <list>          <chr>     <list>                  
#> 1 <split [40/10]> Resample1 <group_vfold_cv [4 × 2]>
#> 2 <split [40/10]> Resample2 <group_vfold_cv [4 × 2]>
#> 3 <split [40/10]> Resample3 <group_vfold_cv [4 × 2]>
#> 4 <split [40/10]> Resample4 <group_vfold_cv [4 × 2]>
#> 5 <split [40/10]> Resample5 <group_vfold_cv [4 × 2]>
#> 
#> [[2]]
#> # Nested resampling:
#> #  outer: Group 5-fold cross-validation
#> #  inner: Group 4-fold cross-validation
#> # A tibble: 5 × 3
#>   splits          id        inner_resamples         
#>   <list>          <chr>     <list>                  
#> 1 <split [40/10]> Resample1 <group_vfold_cv [4 × 2]>
#> 2 <split [40/10]> Resample2 <group_vfold_cv [4 × 2]>
#> 3 <split [40/10]> Resample3 <group_vfold_cv [4 × 2]>
#> 4 <split [40/10]> Resample4 <group_vfold_cv [4 × 2]>
#> 5 <split [40/10]> Resample5 <group_vfold_cv [4 × 2]>
```

<sup>Created on 2021-11-12 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>