### PR TITLE
Fix docs for `int_pctl()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -55,5 +55,5 @@ Config/Needs/website:
     tidyverse/tidytemplate
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.1.2.9000
 Config/testthat/edition: 3

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -179,9 +179,9 @@ pctl_single <- function(stats, alpha = 0.05) {
 #'  `TRUE` for the percentile method, the apparent data is never used in calculating
 #'  the percentile confidence interval.
 #' @param statistics An unquoted column name or `dplyr` selector that identifies
-#'  a single column in the data set that contains the individual bootstrap
-#'  estimates. This can be a list column of tidy tibbles (that contains columns
-#'  `term` and `estimate`) or a simple numeric column. For t-intervals, a
+#'  a single column in the data set containing the individual bootstrap
+#'  estimates. This must be a list column of tidy tibbles (with columns
+#'  `term` and `estimate`). For t-intervals, a
 #'  standard tidy column (usually called `std.err`) is required.
 #'  See the examples below.
 #' @param alpha Level of significance

--- a/man/int_pctl.Rd
+++ b/man/int_pctl.Rd
@@ -20,9 +20,9 @@ should be set to \code{TRUE}. Even if the \code{apparent} argument is set to
 the percentile confidence interval.}
 
 \item{statistics}{An unquoted column name or \code{dplyr} selector that identifies
-a single column in the data set that contains the individual bootstrap
-estimates. This can be a list column of tidy tibbles (that contains columns
-\code{term} and \code{estimate}) or a simple numeric column. For t-intervals, a
+a single column in the data set containing the individual bootstrap
+estimates. This must be a list column of tidy tibbles (with columns
+\code{term} and \code{estimate}). For t-intervals, a
 standard tidy column (usually called \code{std.err}) is required.
 See the examples below.}
 

--- a/man/rsample-package.Rd
+++ b/man/rsample-package.Rd
@@ -6,7 +6,7 @@
 \alias{rsample-package}
 \title{rsample: General Resampling Infrastructure}
 \description{
-\if{html}{\figure{logo.png}{options: align='right' alt='logo' width='120'}}
+\if{html}{\figure{logo.png}{options: style='float: right' alt='logo' width='120'}}
 
 Classes and functions to create and summarize different types of resampling objects (e.g. bootstrap, cross-validation).
 }


### PR DESCRIPTION
Closes #285 

Now the docs say:

> An unquoted column name or `dplyr` selector that identifies a single column in the data set containing the individual bootstrap estimates. This must be a list column of tidy tibbles (with columns `term` and `estimate`). For t-intervals, a standard tidy column (usually called `std.err`) is required. See the examples below.