### PR TITLE
No more double `vars_select()` 🚫 

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,14 @@
 
 * Finally removed the `gather()` method for `rset` objects. Use `tidyr::pivot_longer()` instead (#280).
 
+* Changed `initial_split()` to avoid calling tidyselect twice on `strata` (#296). This fix stops `initial_split()` from generating messages like:
+
+```
+  Note: Using an external vector in selections is ambiguous.
+  i Use `all_of(strata)` instead of `strata` to silence this message.
+  i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>.
+```
+
 # rsample 0.1.1
 
 * Updated documentation on stratified sampling (#245).

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -32,18 +32,11 @@
 #'
 initial_split <- function(data, prop = 3 / 4,
                           strata = NULL, breaks = 4, pool = 0.1, ...) {
-  if (!missing(strata)) {
-    strata <- tidyselect::vars_select(names(data), !!enquo(strata))
-    if (length(strata) == 0) {
-      strata <- NULL
-    }
-  }
-
   res <-
     mc_cv(
       data = data,
       prop = prop,
-      strata = strata,
+      strata = {{ strata }},
       breaks = breaks,
       pool = pool,
       times = 1,


### PR DESCRIPTION
Before this PR, `tidyselect::vars_select()` was called twice inside of `initial_split()`. This generated messages like:

```
"Message"
"  Note: Using an external vector in selections is ambiguous."
"  i Use `all_of(group)` instead of `group` to silence this message."
"  i See <https://tidyselect.r-lib.org/reference/faq-external-vector.html>."
"  This message is displayed once per session."
```

We don't need to `vars_select()` twice, and instead can pass `strata` as `{{ strata }}`. Closes #294 
