### PR TITLE
Add noSuggests check

### DIFF
--- a/.github/workflows/R-CMD-check-hard.yaml
+++ b/.github/workflows/R-CMD-check-hard.yaml
@@ -1,0 +1,57 @@
+# Workflow derived from https://github.com/r-lib/actions/tree/v2/examples
+# Need help debugging build failures? Start at https://github.com/r-lib/actions#where-to-find-help
+#
+# NOTE: This workflow only directly installs "hard" dependencies, i.e. Depends,
+# Imports, and LinkingTo dependencies. Notably, Suggests dependencies are never
+# installed, with the exception of testthat, knitr, and rmarkdown. The cache is
+# never used to avoid accidentally restoring a cache containing a suggested
+# dependency.
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+name: R-CMD-check-hard
+
+jobs:
+  R-CMD-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - {os: ubuntu-18.04,   r: 'release'}
+
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      R_KEEP_PKG_SOURCE: yes
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - uses: r-lib/actions/setup-pandoc@v2
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: ${{ matrix.config.r }}
+          http-user-agent: ${{ matrix.config.http-user-agent }}
+          use-public-rspm: true
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          dependencies: '"hard"'
+          cache: false
+          extra-packages: |
+            any::rcmdcheck
+            any::testthat
+            any::knitr
+            any::rmarkdown
+          needs: check
+
+      - uses: r-lib/actions/check-r-package@v2
+        with:
+          upload-snapshots: true

--- a/R/boot.R
+++ b/R/boot.R
@@ -23,7 +23,7 @@
 #' @return A tibble with classes `bootstraps`, `rset`, `tbl_df`, `tbl`, and
 #'  `data.frame`. The results include a column for the data split objects and a
 #'  column called `id` that has a character string with the resample identifier.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' bootstraps(mtcars, times = 2)
 #' bootstraps(mtcars, times = 2, apparent = TRUE)
 #'

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -204,7 +204,7 @@ pctl_single <- function(stats, alpha = 0.05) {
 #'  Application_. Cambridge: Cambridge University Press.
 #'  doi:10.1017/CBO9780511802843
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("broom")
 #' \donttest{
 #' library(broom)
 #' library(dplyr)

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -14,7 +14,7 @@
 #' @export
 #' @return An `rsplit` object that can be used with the `training` and `testing`
 #'  functions to extract the data in each split.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' set.seed(1353)
 #' car_split <- initial_split(mtcars)
 #' train_data <- training(car_split)

--- a/R/mc.R
+++ b/R/mc.R
@@ -12,7 +12,7 @@
 #' @return An tibble with classes `mc_cv`, `rset`, `tbl_df`, `tbl`, and
 #'  `data.frame`. The results include a column for the data split objects and a
 #'  column called `id` that has a character string with the resample identifier.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' mc_cv(mtcars, times = 2)
 #' mc_cv(mtcars, prop = .5, times = 2)
 #'

--- a/R/reg_intervals.R
+++ b/R/reg_intervals.R
@@ -26,7 +26,7 @@
 #'
 #' _Bootstrap Confidence Intervals_,
 #' \url{https://rsample.tidymodels.org/articles/Applications/Intervals.html}
-#' @examples
+#' @examplesIf rlang::is_installed("broom")
 #' \donttest{
 #' set.seed(1)
 #' reg_intervals(mpg ~ I(1 / sqrt(disp)), data = mtcars)
@@ -37,6 +37,9 @@
 reg_intervals <-
   function(formula, data, model_fn = "lm", type = "student-t", times = NULL,
            alpha = 0.05, filter = term != "(Intercept)", keep_reps = FALSE, ...) {
+
+    rlang::check_installed("broom")
+
     model_fn <- rlang::arg_match(model_fn, c("lm", "glm", "survreg", "coxph"))
     type <- rlang::arg_match(type, c("student-t", "percentile"))
 

--- a/R/rolling_origin.R
+++ b/R/rolling_origin.R
@@ -34,7 +34,7 @@
 #'  and `data.frame`. The results include a column for the data split objects
 #'  and a column called `id` that has a character string with the resample
 #'  identifier.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' set.seed(1131)
 #' ex_data <- data.frame(row = 1:20, some_var = rnorm(20))
 #' dim(rolling_origin(ex_data))

--- a/R/slide.R
+++ b/R/slide.R
@@ -127,7 +127,7 @@
 #'
 #' @name slide-resampling
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' library(vctrs)
 #' library(tibble)
 #' library(modeldata)

--- a/R/tidy.R
+++ b/R/tidy.R
@@ -17,7 +17,7 @@
 #' @details Note that for nested resampling, the rows of the inner resample,
 #'  named `inner_Row`, are *relative* row indices and do not correspond to the
 #'  rows in the original data set.
-#' @examples
+#' @examplesIf rlang::is_installed("ggplot2")
 #' library(ggplot2)
 #' theme_set(theme_bw())
 #'

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -17,7 +17,7 @@
 #'  and `data.frame`. The results include a column for the data split objects
 #'  and a column called `id` that has a character string with the resample
 #'  identifier.
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' validation_split(mtcars, prop = .9)
 #'
 #' data(drinks, package = "modeldata")

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -26,7 +26,7 @@
 #'  For repeats, `id` is the repeat number and an additional column called `id2`
 #'  that contains the fold information (within repeat).
 #'
-#' @examples
+#' @examplesIf rlang::is_installed("modeldata")
 #' vfold_cv(mtcars, v = 10)
 #' vfold_cv(mtcars, v = 10, repeats = 2)
 #'

--- a/man/bootstraps.Rd
+++ b/man/bootstraps.Rd
@@ -66,6 +66,7 @@ which are then used to stratify. Strata below 10\% of the total are
 pooled together; see \code{\link[=make_strata]{make_strata()}} for more details.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 bootstraps(mtcars, times = 2)
 bootstraps(mtcars, times = 2, apparent = TRUE)
 
@@ -102,4 +103,5 @@ map_dbl(
     mean(dat == "Yes")
   }
 )
+\dontshow{\}) # examplesIf}
 }

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -71,6 +71,7 @@ which are then used to stratify. Strata below 10\% of the total are
 pooled together; see \code{\link[=make_strata]{make_strata()}} for more details.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 set.seed(1353)
 car_split <- initial_split(mtcars)
 train_data <- training(car_split)
@@ -92,5 +93,5 @@ set.seed(1353)
 car_split <- group_initial_split(mtcars, cyl)
 train_data <- training(car_split)
 test_data <- testing(car_split)
-
+\dontshow{\}) # examplesIf}
 }

--- a/man/int_pctl.Rd
+++ b/man/int_pctl.Rd
@@ -56,6 +56,7 @@ that was used to create the statistics of interest and are
 computationally taxing.
 }
 \examples{
+\dontshow{if (rlang::is_installed("broom")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{
 library(broom)
 library(dplyr)
@@ -93,6 +94,7 @@ bootstraps(Sacramento, 1000, apparent = TRUE) \%>\%
   mutate(correlations = map(splits, rank_corr)) \%>\%
   int_pctl(correlations)
 }
+\dontshow{\}) # examplesIf}
 }
 \references{
 Davison, A., & Hinkley, D. (1997). \emph{Bootstrap Methods and their

--- a/man/mc_cv.Rd
+++ b/man/mc_cv.Rd
@@ -47,6 +47,7 @@ which are then used to stratify. Strata below 10\% of the total are
 pooled together; see \code{\link[=make_strata]{make_strata()}} for more details.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 mc_cv(mtcars, times = 2)
 mc_cv(mtcars, prop = .5, times = 2)
 
@@ -82,4 +83,5 @@ map_dbl(
     mean(dat == "Yes")
   }
 )
+\dontshow{\}) # examplesIf}
 }

--- a/man/reg_intervals.Rd
+++ b/man/reg_intervals.Rd
@@ -49,6 +49,7 @@ called ".replicates" is also returned.
 A convenience function for confidence intervals with linear-ish parametric models
 }
 \examples{
+\dontshow{if (rlang::is_installed("broom")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 \donttest{
 set.seed(1)
 reg_intervals(mpg ~ I(1 / sqrt(disp)), data = mtcars)
@@ -56,6 +57,7 @@ reg_intervals(mpg ~ I(1 / sqrt(disp)), data = mtcars)
 set.seed(1)
 reg_intervals(mpg ~ I(1 / sqrt(disp)), data = mtcars, keep_reps = TRUE)
 }
+\dontshow{\}) # examplesIf}
 }
 \references{
 Davison, A., & Hinkley, D. (1997). \emph{Bootstrap Methods and their

--- a/man/rolling_origin.Rd
+++ b/man/rolling_origin.Rd
@@ -60,6 +60,7 @@ will make the analysis data set to operate on \emph{weeks} instead of days. The
 assessment set size is not affected by this option.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 set.seed(1131)
 ex_data <- data.frame(row = 1:20, some_var = rnorm(20))
 dim(rolling_origin(ex_data))
@@ -81,6 +82,7 @@ multi_year_roll <- rolling_origin(drinks_annual, cumulative = FALSE)
 
 analysis(multi_year_roll$splits[[1]])
 assessment(multi_year_roll$splits[[1]])
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=sliding_window]{sliding_window()}}, \code{\link[=sliding_index]{sliding_index()}}, and \code{\link[=sliding_period]{sliding_period()}} for additional

--- a/man/slide-resampling.Rd
+++ b/man/slide-resampling.Rd
@@ -163,6 +163,7 @@ windows from daily data.
 }
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(vctrs)
 library(tibble)
 library(modeldata)
@@ -236,6 +237,7 @@ sliding_period(
   skip = 4,
   step = 2
 )
+\dontshow{\}) # examplesIf}
 }
 \seealso{
 \code{\link[=rolling_origin]{rolling_origin()}}

--- a/man/tidy.rsplit.Rd
+++ b/man/tidy.rsplit.Rd
@@ -43,6 +43,7 @@ named \code{inner_Row}, are \emph{relative} row indices and do not correspond to
 rows in the original data set.
 }
 \examples{
+\dontshow{if (rlang::is_installed("ggplot2")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 library(ggplot2)
 theme_set(theme_bw())
 
@@ -81,4 +82,5 @@ ts_cv <- tidy(ts_cv)
 ggplot(ts_cv, aes(x = Resample, y = factor(Row), fill = Data)) +
   geom_tile() +
   scale_fill_brewer()
+\dontshow{\}) # examplesIf}
 }

--- a/man/validation_split.Rd
+++ b/man/validation_split.Rd
@@ -65,10 +65,12 @@ which are then used to stratify. Strata below 10\% of the total are
 pooled together; see \code{\link[=make_strata]{make_strata()}} for more details.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 validation_split(mtcars, prop = .9)
 
 data(drinks, package = "modeldata")
 validation_time_split(drinks)
 
 group_validation_split(mtcars, cyl)
+\dontshow{\}) # examplesIf}
 }

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -57,6 +57,7 @@ which are then used to stratify. Strata below 10\% of the total are
 pooled together; see \code{\link[=make_strata]{make_strata()}} for more details.
 }
 \examples{
+\dontshow{if (rlang::is_installed("modeldata")) (if (getRversion() >= "3.4") withAutoprint else force)(\{ # examplesIf}
 vfold_cv(mtcars, v = 10)
 vfold_cv(mtcars, v = 10, repeats = 2)
 
@@ -92,4 +93,5 @@ map_dbl(
     mean(dat == "Yes")
   }
 )
+\dontshow{\}) # examplesIf}
 }

--- a/tests/testthat/test-bootci.R
+++ b/tests/testthat/test-bootci.R
@@ -4,8 +4,6 @@ sigma <- 1
 
 set.seed(888)
 rand_nums <- rnorm(n, mu, sigma)
-ttest <- broom::tidy(t.test(rand_nums))
-ttest_lower_conf <- broom::tidy(t.test(rand_nums, conf.level = 0.8))
 dat <- data.frame(x = rand_nums)
 
 set.seed(456765)
@@ -16,7 +14,10 @@ bt_norm <-
   )
 
 test_that("Bootstrap estimate of mean is close to estimate of mean from normal distribution", {
+  skip_if_not(rlang::is_installed("broom"))
   skip_on_cran()
+  ttest <- broom::tidy(t.test(rand_nums))
+  ttest_lower_conf <- broom::tidy(t.test(rand_nums, conf.level = 0.8))
   single_pct_res <- int_pctl(bt_norm, stats)
 
   single_t_res <- int_t(bt_norm, stats)
@@ -81,6 +82,7 @@ test_that("Bootstrap estimate of mean is close to estimate of mean from normal d
 # ------------------------------------------------------------------------------
 
 test_that("Wrappers -- selection of multiple variables works", {
+  skip_if_not(rlang::is_installed("modeldata"))
   data("attrition", package = "modeldata")
   func <- function(split, ...) {
     lm(Age ~ HourlyRate + DistanceFromHome, data = analysis(split)) %>% tidy()

--- a/tests/testthat/test-bootci.R
+++ b/tests/testthat/test-bootci.R
@@ -232,6 +232,7 @@ test_that("bad input", {
 # ------------------------------------------------------------------------------
 
 test_that("regression intervals", {
+  skip_if_not(rlang::is_installed("broom"))
   skip_on_cran()
 
   expect_error(

--- a/tests/testthat/test-initial.R
+++ b/tests/testthat/test-initial.R
@@ -28,6 +28,7 @@ test_that("default time param with lag", {
   expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3 / 4)))
   expect_equal(ts1, dat1[(floor(nrow(dat1) * 3 / 4) + 1 - 5):nrow(dat1), ])
 
+  skip_if_not(rlang::is_installed("modeldata"))
   data(drinks, package = "modeldata")
 
   # Whole numbers only

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -46,6 +46,7 @@ test_that("default time param", {
 })
 
 test_that("default time param with lag", {
+  skip_if_not(rlang::is_installed("modeldata"))
   data(drinks, package = "modeldata")
 
   rs1 <- validation_time_split(dat1, lag = 5)

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -44,6 +44,7 @@ test_that("repeated", {
 
 test_that("strata", {
   set.seed(11)
+  skip_if_not(rlang::is_installed("modeldata"))
   data("mlc_churn", package = "modeldata")
   rs3 <- vfold_cv(mlc_churn, repeats = 2, strata = "voice_mail_plan")
   sizes3 <- dim_rset(rs3)
@@ -188,6 +189,7 @@ test_that("grouping -- tibble input", {
 })
 
 test_that("grouping -- other balance methods", {
+  skip_if_not(rlang::is_installed("modeldata"))
   data(ames, package = "modeldata")
   set.seed(11)
   rs1 <- group_vfold_cv(

--- a/vignettes/Applications/Intervals.Rmd
+++ b/vignettes/Applications/Intervals.Rmd
@@ -10,11 +10,18 @@ output:
 
 
 ```{r setup, include=FALSE}
+knitr::opts_chunk$set(
+  eval = rlang::is_installed("ggplot2") && rlang::is_installed("modeldata")
+)
+```
+
+```{r package_setup, include = FALSE}
 library(tidymodels)
 library(nlstools)
 library(GGally)
 theme_set(theme_bw())
 ```
+
 
 The bootstrap was originally intended for estimating confidence intervals for complex statistics whose variance properties are difficult to analytically derive. Davison and Hinkley's [_Bootstrap Methods and Their Application_](https://www.cambridge.org/core/books/bootstrap-methods-and-their-application/ED2FD043579F27952363566DC09CBD6A) is a great resource for these methods. `rsample` contains a few function to compute the most common types of intervals. 
 

--- a/vignettes/Applications/Recipes_and_rsample.Rmd
+++ b/vignettes/Applications/Recipes_and_rsample.Rmd
@@ -9,6 +9,9 @@ output:
 ---
 
 ```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  eval = rlang::is_installed("ggplot2") && rlang::is_installed("modeldata")
+)
 options(digits = 3)
 library(rsample)
 library(recipes)

--- a/vignettes/Working_with_rsets.Rmd
+++ b/vignettes/Working_with_rsets.Rmd
@@ -13,12 +13,17 @@ knitr::opts_chunk$set(
   message = FALSE,
   digits = 3,
   collapse = TRUE,
-  comment = "#>"
+  comment = "#>",
+  eval = rlang::is_installed("ggplot2") && rlang::is_installed("modeldata")
   )
 options(digits = 3, width = 90)
+```
+
+```{r ggplot2_setup, include = FALSE}
 library(ggplot2)
 theme_set(theme_bw())
 ```
+
 
 ## Introduction  
 

--- a/vignettes/Working_with_rsets.Rmd
+++ b/vignettes/Working_with_rsets.Rmd
@@ -126,7 +126,7 @@ rs_obj$accuracy <- map_dbl(rs_obj$results, function(x) mean(x$correct))
 summary(rs_obj$accuracy)
 ```
 
-Keep in mind that the baseline accuracy to beat is the rate of non-attrition, which is `r round(mean(attrition$Attrition == "No"), 3)`. Not a great model so far.
+Keep in mind that the baseline accuracy to beat is the rate of non-attrition, which is `r ifelse(rlang::is_installed("modeldata"), round(mean(attrition$Attrition == "No"), 3), 0.839)`. Not a great model so far.
 
 ## Using the Bootstrap to Make Comparisons
 


### PR DESCRIPTION
This PR adds the R-CMD-check-hard action, to ensure that we'll pass noSuggests checks going forward. It also includes code changes to make this new CI pass. Most of these are pretty minimal, skipping tests or examples without suggested packages; the most invasive is that `reg_intervals()` now calls `rlang::check_installed()` at its start.