### PR TITLE
Swap the order of 'repeats' and 'balance'

### DIFF
--- a/R/vfold.R
+++ b/R/vfold.R
@@ -182,7 +182,7 @@ vfold_splits <- function(data, v = 10, strata = NULL, breaks = 4, pool = 0.1) {
 #' group_vfold_cv(ames, group = Neighborhood, v = 5, repeats = 2)
 #'
 #' @export
-group_vfold_cv <- function(data, group = NULL, v = NULL, balance = c("groups", "observations"), repeats = 1, ...) {
+group_vfold_cv <- function(data, group = NULL, v = NULL, repeats = 1, balance = c("groups", "observations"), ...) {
 
   group <- validate_group({{ group }}, data)
   balance <- rlang::arg_match(balance)

--- a/man/group_vfold_cv.Rd
+++ b/man/group_vfold_cv.Rd
@@ -8,8 +8,8 @@ group_vfold_cv(
   data,
   group = NULL,
   v = NULL,
-  balance = c("groups", "observations"),
   repeats = 1,
+  balance = c("groups", "observations"),
   ...
 )
 }
@@ -23,11 +23,11 @@ assessment set within a fold.}
 \item{v}{The number of partitions of the data set. If left as \code{NULL}, \code{v}
 will be set to the number of unique values in the group.}
 
+\item{repeats}{The number of times to repeat the V-fold partitioning.}
+
 \item{balance}{If \code{v} is less than the number of unique groups, how should
 groups be combined into folds? Should be one of
 \code{"groups"} or \code{"observations"}.}
-
-\item{repeats}{The number of times to repeat the V-fold partitioning.}
 
 \item{...}{Not currently used.}
 }


### PR DESCRIPTION
This fixes #334. This is a breaking change _on dev_, but since `balance` isn't on CRAN yet doesn't impact the release version.