### PR TITLE
Remove mlbench from website needs

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -50,7 +50,6 @@ VignetteBuilder:
     knitr
 Config/Needs/website: 
     GGally,
-    mlbench,
     nlstools, 
     tidymodels,
     tidyverse/tidytemplate


### PR DESCRIPTION
This PR fixes #314 now that a new version of downlit is on CRAN. 