### PR TITLE
Force sorting from vec_count (fixes #342)

### DIFF
--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -77,7 +77,7 @@ balance_observations <- function(data_ind, v, ...) {
   n_obs <- nrow(data_ind)
   target_per_fold <- 1 / v
 
-  freq_table <- vec_count(data_ind$..group)
+  freq_table <- vec_count(data_ind$..group, sort = "key")
   freq_table <- freq_table[sample.int(nrow(freq_table)), ]
   freq_table$assignment <- NA
   freq_table$assignment[seq_len(v)] <- seq_len(v)
@@ -115,7 +115,7 @@ balance_prop <- function(prop, data_ind, v, replace = FALSE, ...) {
   }
   n_obs <- nrow(data_ind)
 
-  freq_table <- vec_count(data_ind$..group)
+  freq_table <- vec_count(data_ind$..group, sort = "key")
 
   n <- nrow(freq_table)
   # If sampling with replacement,

--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -77,7 +77,7 @@ balance_observations <- function(data_ind, v, ...) {
   n_obs <- nrow(data_ind)
   target_per_fold <- 1 / v
 
-  freq_table <- vec_count(data_ind$..group, sort = "key")
+  freq_table <- vec_count(data_ind$..group, sort = "location")
   freq_table <- freq_table[sample.int(nrow(freq_table)), ]
   freq_table$assignment <- NA
   freq_table$assignment[seq_len(v)] <- seq_len(v)
@@ -115,7 +115,7 @@ balance_prop <- function(prop, data_ind, v, replace = FALSE, ...) {
   }
   n_obs <- nrow(data_ind)
 
-  freq_table <- vec_count(data_ind$..group, sort = "key")
+  freq_table <- vec_count(data_ind$..group, sort = "location")
 
   n <- nrow(freq_table)
   # If sampling with replacement,

--- a/tests/testthat/_snaps/make_groups.md
+++ b/tests/testthat/_snaps/make_groups.md
@@ -7,15 +7,15 @@
          name     height  mass hair_color skin_color eye_color birth_year sex   gender
          <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
        1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
-       2 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
-       3 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
-       4 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
-       5 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       2 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       3 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       4 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
+       5 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
        6 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
-       7 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
-       8 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
-       9 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
-      10 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+       7 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+       8 Biggs D~    183    84 black      light      brown           24   male  mascu~
+       9 Biggs D~    183    84 black      light      brown           24   male  mascu~
+      10 Biggs D~    183    84 black      light      brown           24   male  mascu~
       # ... with 77 more rows, and 5 more variables: homeworld <chr>, species <chr>,
       #   films <list>, vehicles <list>, starships <list>
 
@@ -48,16 +48,16 @@
       # A tibble: 65 x 14
          name     height  mass hair_color skin_color eye_color birth_year sex   gender
          <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
-       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
-       2 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
-       3 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
-       4 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
-       5 Biggs D~    183    84 black      light      brown           24   male  mascu~
-       6 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
-       7 Anakin ~    188    84 blond      fair       blue            41.9 male  mascu~
-       8 Wilhuff~    180    NA auburn, g~ fair       blue            64   male  mascu~
-       9 Chewbac~    228   112 brown      unknown    blue           200   male  mascu~
-      10 Han Solo    180    80 brown      fair       brown           29   male  mascu~
+       1 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       2 R2-D2        96    32 <NA>       white, bl~ red             33   none  mascu~
+       3 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
+       4 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
+       5 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+       6 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+       7 Biggs D~    183    84 black      light      brown           24   male  mascu~
+       8 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
+       9 Anakin ~    188    84 blond      fair       blue            41.9 male  mascu~
+      10 Greedo      173    74 <NA>       green      black           44   male  mascu~
       # ... with 55 more rows, and 5 more variables: homeworld <chr>, species <chr>,
       #   films <list>, vehicles <list>, starships <list>
 
@@ -69,16 +69,16 @@
       # A tibble: 65 x 14
          name     height  mass hair_color skin_color eye_color birth_year sex   gender
          <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
-       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
-       2 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
-       3 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       1 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       2 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       3 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
        4 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
        5 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
-       6 Biggs D~    183    84 black      light      brown           24   male  mascu~
-       7 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
-       8 Wilhuff~    180    NA auburn, g~ fair       blue            64   male  mascu~
-       9 Chewbac~    228   112 brown      unknown    blue           200   male  mascu~
-      10 Han Solo    180    80 brown      fair       brown           29   male  mascu~
+       6 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+       7 Biggs D~    183    84 black      light      brown           24   male  mascu~
+       8 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
+       9 Wilhuff~    180    NA auburn, g~ fair       blue            64   male  mascu~
+      10 Chewbac~    228   112 brown      unknown    blue           200   male  mascu~
       # ... with 55 more rows, and 5 more variables: homeworld <chr>, species <chr>,
       #   films <list>, vehicles <list>, starships <list>
 

--- a/tests/testthat/_snaps/make_groups.md
+++ b/tests/testthat/_snaps/make_groups.md
@@ -1,0 +1,84 @@
+# grouped variants are consistent across R sessions
+
+    Code
+      analysis(rs$splits[[1]])
+    Output
+      # A tibble: 87 x 14
+         name     height  mass hair_color skin_color eye_color birth_year sex   gender
+         <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
+       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
+       2 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
+       3 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       4 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       5 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       6 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
+       7 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
+       8 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
+       9 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+      10 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+      # ... with 77 more rows, and 5 more variables: homeworld <chr>, species <chr>,
+      #   films <list>, vehicles <list>, starships <list>
+
+---
+
+    Code
+      analysis(rs$splits[[1]])
+    Output
+      # A tibble: 86 x 14
+         name     height  mass hair_color skin_color eye_color birth_year sex   gender
+         <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
+       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
+       2 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       3 R2-D2        96    32 <NA>       white, bl~ red             33   none  mascu~
+       4 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       5 Leia Or~    150    49 brown      light      brown           19   fema~ femin~
+       6 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
+       7 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+       8 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+       9 Biggs D~    183    84 black      light      brown           24   male  mascu~
+      10 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
+      # ... with 76 more rows, and 5 more variables: homeworld <chr>, species <chr>,
+      #   films <list>, vehicles <list>, starships <list>
+
+---
+
+    Code
+      analysis(rs$splits[[1]])
+    Output
+      # A tibble: 65 x 14
+         name     height  mass hair_color skin_color eye_color birth_year sex   gender
+         <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
+       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
+       2 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       3 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+       4 R5-D4        97    32 <NA>       white, red red             NA   none  mascu~
+       5 Biggs D~    183    84 black      light      brown           24   male  mascu~
+       6 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
+       7 Anakin ~    188    84 blond      fair       blue            41.9 male  mascu~
+       8 Wilhuff~    180    NA auburn, g~ fair       blue            64   male  mascu~
+       9 Chewbac~    228   112 brown      unknown    blue           200   male  mascu~
+      10 Han Solo    180    80 brown      fair       brown           29   male  mascu~
+      # ... with 55 more rows, and 5 more variables: homeworld <chr>, species <chr>,
+      #   films <list>, vehicles <list>, starships <list>
+
+---
+
+    Code
+      analysis(rs$splits[[1]])
+    Output
+      # A tibble: 65 x 14
+         name     height  mass hair_color skin_color eye_color birth_year sex   gender
+         <chr>     <int> <dbl> <chr>      <chr>      <chr>          <dbl> <chr> <chr> 
+       1 Luke Sk~    172    77 blond      fair       blue            19   male  mascu~
+       2 C-3PO       167    75 <NA>       gold       yellow         112   none  mascu~
+       3 Darth V~    202   136 none       white      yellow          41.9 male  mascu~
+       4 Owen La~    178   120 brown, gr~ light      blue            52   male  mascu~
+       5 Beru Wh~    165    75 brown      light      blue            47   fema~ femin~
+       6 Biggs D~    183    84 black      light      brown           24   male  mascu~
+       7 Obi-Wan~    182    77 auburn, w~ fair       blue-gray       57   male  mascu~
+       8 Wilhuff~    180    NA auburn, g~ fair       blue            64   male  mascu~
+       9 Chewbac~    228   112 brown      unknown    blue           200   male  mascu~
+      10 Han Solo    180    80 brown      fair       brown           29   male  mascu~
+      # ... with 55 more rows, and 5 more variables: homeworld <chr>, species <chr>,
+      #   films <list>, vehicles <list>, starships <list>
+

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -56,11 +56,11 @@
       # A tibble: 5 x 2
         splits             id       
         <list>             <chr>    
-      1 <split [2360/570]> Resample1
-      2 <split [2225/705]> Resample2
-      3 <split [2379/551]> Resample3
-      4 <split [2412/518]> Resample4
-      5 <split [2344/586]> Resample5
+      1 <split [2364/566]> Resample1
+      2 <split [2371/559]> Resample2
+      3 <split [2360/570]> Resample3
+      4 <split [2278/652]> Resample4
+      5 <split [2347/583]> Resample5
 
 # grouping -- printing
 

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -56,11 +56,11 @@
       # A tibble: 5 x 2
         splits             id       
         <list>             <chr>    
-      1 <split [2345/585]> Resample1
-      2 <split [2290/640]> Resample2
-      3 <split [2360/570]> Resample3
-      4 <split [2344/586]> Resample4
-      5 <split [2381/549]> Resample5
+      1 <split [2360/570]> Resample1
+      2 <split [2225/705]> Resample2
+      3 <split [2379/551]> Resample3
+      4 <split [2412/518]> Resample4
+      5 <split [2344/586]> Resample5
 
 # grouping -- printing
 

--- a/tests/testthat/test-make_groups.R
+++ b/tests/testthat/test-make_groups.R
@@ -28,3 +28,18 @@ test_that("grouped variants have the same classes as nongrouped outputs", {
   )
 
 })
+
+test_that("grouped variants are consistent across R sessions", {
+  skip_if_not(rlang::is_installed("withr"))
+  grouped_variants <- grep("^group_", names(rset_subclasses), value = TRUE)
+
+  for (x in grouped_variants) {
+    withr::with_seed(
+      123,
+      rs <- do.call(x, list(data = dplyr::starwars, group = "name"))
+    )
+    expect_snapshot(
+      analysis(rs$splits[[1]])
+    )
+  }
+})


### PR DESCRIPTION
This PR fixes #342 by:

+ Forcing `vec_count()` to sort by key (we had been using the default sort)
+ Testing for consistent output from grouped resampling functions across CI runs
