### PR TITLE
Fix link

### DIFF
--- a/R/slide.R
+++ b/R/slide.R
@@ -37,7 +37,7 @@
 #'
 #' @param period The period to group the `index` by. This is specified as a
 #'   single string, such as `"year"` or `"month"`. See the `.period` argument
-#'   of [slider::slide_index()] for the full list of options and further
+#'   of [slider::slide_period()] for the full list of options and further
 #'   explanation.
 #'
 #' @param lookback The number of elements to look back from the current element

--- a/man/slide-resampling.Rd
+++ b/man/slide-resampling.Rd
@@ -127,7 +127,7 @@ allowed. Additionally, the index cannot contain any missing values.}
 
 \item{period}{The period to group the \code{index} by. This is specified as a
 single string, such as \code{"year"} or \code{"month"}. See the \code{.period} argument
-of \code{\link[slider:slide_index]{slider::slide_index()}} for the full list of options and further
+of \code{\link[slider:slide_period]{slider::slide_period()}} for the full list of options and further
 explanation.}
 
 \item{every}{A single positive integer. The number of periods to group


### PR DESCRIPTION
Tiny PR to update the link for `slide_period()`'s period argument.

This PR fixes #345 