### PR TITLE
Warn when bootstraps returns the apparent

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # rsample (development version)
 
+* `group_bootstraps()` now warns if resampling returns any empty assessment sets (previously had been an error) (#356) (#357).
+
+* `bootstraps()` now warns if resampling returns any empty assessment sets (previously had no message or warning) (#356) (#357).
+
 * Added a new function, `clustering_cv()`, for blocked cross-validation in various predictor spaces. This is a very flexible function, taking arguments to both `distance_function` and `cluster_function`, allowing it to be used for spatial clustering as well as potentially phylogenetic and other forms of clustering (#351).
 
 # rsample 1.1.0

--- a/R/boot.R
+++ b/R/boot.R
@@ -84,6 +84,7 @@ bootstraps <-
         breaks = breaks,
         pool = pool
       )
+
     if (apparent) {
       split_objs <- bind_rows(split_objs, apparent(data))
     }
@@ -144,6 +145,15 @@ boot_splits <-
 
     split_objs <-
       purrr::map(indices, make_splits, data = data, class = "boot_split")
+
+    all_assessable <- purrr::map(split_objs, function(x) nrow(assessment(x)))
+    if (any(all_assessable == 0)) {
+      rlang::warn(
+        "Some assessment sets contained zero rows.",
+        call = rlang::caller_env()
+      )
+    }
+
     list(
       splits = split_objs,
       id = names0(length(split_objs), "Bootstrap")
@@ -230,13 +240,13 @@ group_boot_splits <- function(data, group, times = 25) {
   indices <- lapply(indices, boot_complement, n = n)
   split_objs <-
     purrr::map(indices, make_splits, data = data, class = c("group_boot_split", "boot_split"))
-  all_assessable <- purrr::map(split_objs, function(x) nrow(assessment(x)))
 
+  all_assessable <- purrr::map(split_objs, function(x) nrow(assessment(x)))
   if (any(all_assessable == 0)) {
-    rlang::abort(
+    rlang::warn(
       c(
-        "Some assessment sets contained zero rows",
-        i = "Consider using a non-grouped resampling method"
+        "Some assessment sets contained zero rows.",
+        i = "Consider using a non-grouped resampling method."
       ),
       call = rlang::caller_env()
     )

--- a/tests/testthat/_snaps/boot.md
+++ b/tests/testthat/_snaps/boot.md
@@ -3,9 +3,51 @@
     Code
       group_bootstraps(warpbreaks, tension)
     Condition
-      Error in `group_bootstraps()`:
-      ! Some assessment sets contained zero rows
-      i Consider using a non-grouped resampling method
+      Warning in `group_bootstraps()`:
+      Some assessment sets contained zero rows.
+      i Consider using a non-grouped resampling method.
+    Output
+      # Group bootstrap sampling 
+      # A tibble: 25 x 2
+         splits          id         
+         <list>          <chr>      
+       1 <split [54/18]> Bootstrap01
+       2 <split [54/36]> Bootstrap02
+       3 <split [54/18]> Bootstrap03
+       4 <split [54/18]> Bootstrap04
+       5 <split [54/36]> Bootstrap05
+       6 <split [54/18]> Bootstrap06
+       7 <split [54/18]> Bootstrap07
+       8 <split [54/18]> Bootstrap08
+       9 <split [54/18]> Bootstrap09
+      10 <split [54/18]> Bootstrap10
+      # ... with 15 more rows
+      # i Use `print(n = ...)` to see more rows
+
+---
+
+    Code
+      bootstraps(mtcars[2, ])
+    Condition
+      Warning in `bootstraps()`:
+      Some assessment sets contained zero rows.
+    Output
+      # Bootstrap sampling 
+      # A tibble: 25 x 2
+         splits        id         
+         <list>        <chr>      
+       1 <split [1/0]> Bootstrap01
+       2 <split [1/0]> Bootstrap02
+       3 <split [1/0]> Bootstrap03
+       4 <split [1/0]> Bootstrap04
+       5 <split [1/0]> Bootstrap05
+       6 <split [1/0]> Bootstrap06
+       7 <split [1/0]> Bootstrap07
+       8 <split [1/0]> Bootstrap08
+       9 <split [1/0]> Bootstrap09
+      10 <split [1/0]> Bootstrap10
+      # ... with 15 more rows
+      # i Use `print(n = ...)` to see more rows
 
 # printing
 

--- a/tests/testthat/test-boot.R
+++ b/tests/testthat/test-boot.R
@@ -107,8 +107,10 @@ test_that("bad args", {
   expect_error(bootstraps(warpbreaks, strata = c("tension", "wool")))
   set.seed(1)
   expect_snapshot(
-    group_bootstraps(warpbreaks, tension),
-    error = TRUE
+    group_bootstraps(warpbreaks, tension)
+  )
+  expect_snapshot(
+    bootstraps(mtcars[2, ])
   )
 })
 


### PR DESCRIPTION
Fixes #356

``` r
library(rsample)

bootstraps(mtcars[1, ])
#> Warning in bootstraps(mtcars[1, ]): Some assessment sets contained zero rows.
#> # Bootstrap sampling 
#> # A tibble: 25 × 2
#>    splits        id         
#>    <list>        <chr>      
#>  1 <split [1/0]> Bootstrap01
#>  2 <split [1/0]> Bootstrap02
#>  3 <split [1/0]> Bootstrap03
#>  4 <split [1/0]> Bootstrap04
#>  5 <split [1/0]> Bootstrap05
#>  6 <split [1/0]> Bootstrap06
#>  7 <split [1/0]> Bootstrap07
#>  8 <split [1/0]> Bootstrap08
#>  9 <split [1/0]> Bootstrap09
#> 10 <split [1/0]> Bootstrap10
#> # … with 15 more rows
#> # ℹ Use `print(n = ...)` to see more rows
group_bootstraps(mtcars, cyl)
#> Warning in group_bootstraps(mtcars, cyl): Some assessment sets contained zero rows.
#> ℹ Consider using a non-grouped resampling method.
#> # Group bootstrap sampling 
#> # A tibble: 25 × 2
#>    splits          id         
#>    <list>          <chr>      
#>  1 <split [36/7]>  Bootstrap01
#>  2 <split [35/11]> Bootstrap02
#>  3 <split [36/7]>  Bootstrap03
#>  4 <split [35/11]> Bootstrap04
#>  5 <split [33/21]> Bootstrap05
#>  6 <split [39/7]>  Bootstrap06
#>  7 <split [28/11]> Bootstrap07
#>  8 <split [29/14]> Bootstrap08
#>  9 <split [29/14]> Bootstrap09
#> 10 <split [36/7]>  Bootstrap10
#> # … with 15 more rows
#> # ℹ Use `print(n = ...)` to see more rows
```

<sup>Created on 2022-08-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>