### PR TITLE
Randomize strata

### DIFF
--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -130,12 +130,22 @@ balance_groups_strata <- function(data_ind, v, ...) {
   #
   # This means that, if nrow(keys) %% v == 0, each fold should have
   # the same number of groups from each strata
-  folds <- split_unnamed(folds, sort(keys$..strata))
+  #
+  # We randomize "keys" here so that the function is stochastic even for
+  # strata with only one group:
+  unique_strata <- unique(keys$..strata)
+  keys_order <- sample.int(length(unique_strata))
+
+  # Re-order the keys data.frame based on the reshuffled strata variable:
+  keys <- keys[
+    order(match(keys$..strata, unique_strata[keys_order])),
+  ]
+
+  # And split both folds and keys with the reordered strata vector:
+  folds <- split_unnamed(folds, keys$..strata)
   keys <- split_unnamed(keys, keys$..strata)
 
   # Randomly assign fold IDs to each group within each strata
-  # This is the only step here with any randomness in it
-  # If each strata only has one group, this function is deterministic
   keys <- purrr::map2(
     keys,
     folds,

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -70,11 +70,11 @@
       # A tibble: 5 x 5
         analysis assessment      n     p id       
            <int>      <int>  <int> <int> <chr>    
-      1    79814      20186 100000     3 Resample1
-      2    80195      19805 100000     3 Resample2
-      3    80109      19891 100000     3 Resample3
-      4    79831      20169 100000     3 Resample4
-      5    80051      19949 100000     3 Resample5
+      1    80004      19996 100000     3 Resample1
+      2    79850      20150 100000     3 Resample2
+      3    79912      20088 100000     3 Resample3
+      4    80131      19869 100000     3 Resample4
+      5    80103      19897 100000     3 Resample5
 
 # grouping -- printing
 


### PR DESCRIPTION
This is a follow-up to #360 . I realized that the function was deterministic for any strata with only one group, and that it would always "short change" the last strata in the vector by giving it fewer folds as options (if `length(unique(strata)) %% v != 0`). Both of these strike me as small, but non-ideal bugs in the function; this PR changes the function so that the order of strata themselves are randomized, which I believe fixes both behaviors.

Sorry to pitch a breaking change right after we merged the first version of the feature -- I had this as a shower thought this morning and realized it wouldn't be that hard to change.

I made this reprex and I don't know that it's actually helpful at all, but here's proof that this stratified sampling works:

``` r
library(rsample)
set.seed(11)

group_table <- tibble::tibble(
  group = 1:100,
  outcome = sample(c(rep(0, 70), rep(1, 30)))
)
observation_table <- tibble::tibble(
  group = sample(1:100, 1e5, replace = TRUE),
  observation = 1:1e5
)
sample_data <- dplyr::full_join(group_table, observation_table, by = "group")

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_vfold_cv(sample_data, group, v = 5, strata = outcome)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_vfold_cv(sample_data, group, v = 5)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.3 - strata_rate))
#> [1] 0.001477664
mean(abs(0.3 - base_rate))
#> [1] 0.01895246
```

<sup>Created on 2022-08-27 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>