### PR TITLE
Make `balance = observations` work with strata

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rsample (development version)
 
-* `group_vfold_cv()` now supports stratification, so long as `balance = "groups"` (the default). Strata must be constant within each group (#317).
+* `group_vfold_cv()` now supports stratification. Strata must be constant within each group (#317, #360, #363, #364).
 
 * `group_bootstraps()` now warns if resampling returns any empty assessment sets (previously had been an error) (#356) (#357).
 

--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -199,9 +199,8 @@ balance_observations_helper <- function(data_split, v, target_per_fold) {
   # (to ensure that each fold gets at least one group assigned):
   freq_table <- freq_table[sample.int(nrow(freq_table)), ]
   freq_table$assignment <- NA
-  # Assign _either_ the first
-  starting_folds <- seq_len(v)[seq_len(min(nrow(freq_table), v))]
-  freq_table$assignment[starting_folds] <- starting_folds
+  # Assign the first `v` rows to folds, so that each fold has _some_ data:
+  freq_table$assignment[seq_len(v)] <- seq_len(v)
 
   # Each run of this loop assigns one "NA" assignment to a fold,
   # so we won't get caught in an endless loop here

--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -168,42 +168,76 @@ balance_observations <- function(data_ind, v, ...) {
   n_obs <- nrow(data_ind)
   target_per_fold <- 1 / v
 
-  freq_table <- vec_count(data_ind$..group, sort = "location")
-  freq_table <- freq_table[sample.int(nrow(freq_table)), ]
-  freq_table$assignment <- NA
-  freq_table$assignment[seq_len(v)] <- seq_len(v)
-
-  while (any(is.na(freq_table$assignment))) {
-    next_row <- which(is.na(freq_table$assignment))[[1]]
-    next_size <- freq_table[next_row, ]$count
-
-    group_breakdown <- freq_table %>%
-      stats::na.omit() %>%
-      dplyr::group_by(.data$assignment) %>%
-      dplyr::summarise(count = sum(.data$count), .groups = "drop") %>%
-      dplyr::mutate(prop = .data$count / n_obs,
-                    pre_error = abs(.data$prop - target_per_fold),
-                    if_added_count = .data$count + next_size,
-                    if_added_prop = .data$if_added_count / n_obs,
-                    post_error = abs(.data$if_added_prop - target_per_fold),
-                    improvement = .data$post_error - .data$pre_error)
-
-    most_improved <- which.min(group_breakdown$improvement)
-    freq_table[next_row, ]$assignment <-
-      group_breakdown[most_improved, ]$assignment
-  }
+  freq_table <- balance_observations_helper(data_ind, v, target_per_fold)
 
   collapse_groups(freq_table, data_ind, v)
 
 }
 
 balance_observations_strata <- function(data_ind, v, ...) {
-  rlang::abort(
-    c(
-      "`balance = 'observations'` has not yet been implemented for grouped resampling with stratification.",
-      i = "Consider setting `balance = 'groups'`"
-    )
+  rlang::check_dots_empty()
+
+  target_per_fold <- 1 / v
+
+  data_splits <- split_unnamed(data_ind, data_ind[["..strata"]])
+  freq_table <- purrr::map_dfr(
+    data_splits,
+    balance_observations_helper,
+    v = v,
+    target_per_fold = target_per_fold
   )
+
+  collapse_groups(freq_table, data_ind, v)
+}
+
+balance_observations_helper <- function(data_split, v, target_per_fold) {
+
+  n_obs <- nrow(data_split)
+  # Create a frequency table counting how many of each group are in the data:
+  freq_table <- vec_count(data_split$..group, sort = "location")
+  # Randomly shuffle that table, then assign the first few rows to folds
+  # (to ensure that each fold gets at least one group assigned):
+  freq_table <- freq_table[sample.int(nrow(freq_table)), ]
+  freq_table$assignment <- NA
+  # Assign _either_ the first
+  starting_folds <- seq_len(v)[seq_len(min(nrow(freq_table), v))]
+  freq_table$assignment[starting_folds] <- starting_folds
+
+  # Each run of this loop assigns one "NA" assignment to a fold,
+  # so we won't get caught in an endless loop here
+  while (any(is.na(freq_table$assignment))) {
+    # Get the index of the next row to be assigned, and its count:
+    next_row <- which(is.na(freq_table$assignment))[[1]]
+    next_size <- freq_table[next_row, ]$count
+
+    # Calculate which fold to assign this new row into:
+    group_breakdown <- freq_table %>%
+      # The only NA column in freq_table should be assignment
+      # So this should only drop un-assigned groups:
+      stats::na.omit() %>%
+      # Group by fold assignments and count data in each fold:
+      dplyr::group_by(.data$assignment) %>%
+      dplyr::summarise(count = sum(.data$count), .groups = "drop") %>%
+      # Calculate...:
+      dplyr::mutate(
+        # The proportion of data in each fold so far,
+        prop = .data$count / n_obs,
+        # The amount off from the target proportion so far,
+        pre_error = abs(.data$prop - target_per_fold),
+        # The amount off from the target proportion if we add this new group,
+        if_added_count = .data$count + next_size,
+        if_added_prop = .data$if_added_count / n_obs,
+        post_error = abs(.data$if_added_prop - target_per_fold),
+        # And how much better or worse adding this new group would make things
+        improvement = .data$post_error - .data$pre_error
+      )
+
+    # Assign the group in question to the best fold and move on to the next one:
+    most_improved <- which.min(group_breakdown$improvement)
+    freq_table[next_row, ]$assignment <-
+      group_breakdown[most_improved, ]$assignment
+  }
+  freq_table
 }
 
 balance_prop <- function(prop, data_ind, v, replace = FALSE, ...) {

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -285,13 +285,13 @@ group_vfold_splits <- function(data, group, v = NULL, balance, strata = NULL, po
         )$count
       )
       message <- c(
-        "Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common strata."
+        "Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common stratum."
       )
 
       if (max_v < 5) {
         rlang::abort(c(
           message,
-          x = glue::glue("The least common strata only had {max_v} groups, which may not be enough for cross-validation."),
+          x = glue::glue("The least common stratum only had {max_v} groups, which may not be enough for cross-validation."),
           i = "Set `v` explicitly to override this error."
         ),
         call = rlang::caller_env())

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -76,6 +76,30 @@
       4    80131      19869 100000     3 Resample4
       5    80103      19897 100000     3 Resample5
 
+---
+
+    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common strata.
+    i Set `v` explicitly to override this warning.
+
+---
+
+    Code
+      sizes5
+    Output
+      # A tibble: 5 x 5
+        analysis assessment      n     p id       
+           <int>      <int>  <int> <int> <chr>    
+      1    80096      19904 100000     3 Resample1
+      2    79962      20038 100000     3 Resample2
+      3    79928      20072 100000     3 Resample3
+      4    80058      19942 100000     3 Resample4
+      5    79956      20044 100000     3 Resample5
+
+---
+
+    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common strata.
+    i Set `v` explicitly to override this warning.
+
 # grouping -- printing
 
     Code

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -78,26 +78,7 @@
 
 ---
 
-    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common strata.
-    i Set `v` explicitly to override this warning.
-
----
-
-    Code
-      sizes5
-    Output
-      # A tibble: 5 x 5
-        analysis assessment      n     p id       
-           <int>      <int>  <int> <int> <chr>    
-      1    80096      19904 100000     3 Resample1
-      2    79962      20038 100000     3 Resample2
-      3    79928      20072 100000     3 Resample3
-      4    80058      19942 100000     3 Resample4
-      5    79956      20044 100000     3 Resample5
-
----
-
-    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common strata.
+    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common stratum.
     i Set `v` explicitly to override this warning.
 
 # grouping -- printing

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -103,7 +103,8 @@ test_that("reshuffle_rset is working", {
         group = "y",
         strata = "z",
         breaks = 2,
-        pool = 0.2
+        pool = 0.2,
+        v = 2
       )
     )
     # Reshuffle them under the same seed to ensure they're identical

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -227,12 +227,12 @@ test_that("grouping -- other balance methods", {
 test_that("grouping -- strata", {
   set.seed(11)
 
-  common_class <- 70
-  rare_class <- 30
+  n_common_class <- 70
+  n_rare_class <- 30
 
   group_table <- tibble(
     group = 1:100,
-    outcome = sample(c(rep(0, common_class), rep(1, rare_class)))
+    outcome = sample(c(rep(0, n_common_class), rep(1, n_rare_class)))
   )
   observation_table <- tibble(
     group = sample(1:100, 1e5, replace = TRUE),

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -270,7 +270,7 @@ test_that("grouping -- strata", {
         group_vfold_cv(sample_data, group, strata = outcome)
       )
     ),
-    rare_class
+    n_rare_class
   )
 
   rs5 <- group_vfold_cv(
@@ -315,7 +315,7 @@ test_that("grouping -- strata", {
         )
       )
     ),
-    rare_class
+    n_rare_class
   )
 })
 


### PR DESCRIPTION
Here's a draft implementation of how stratification might work with `balance = observations` for `group_vfold_cv()`. 

``` r
library(rsample)
set.seed(11)

group_table <- tibble::tibble(
  group = 1:100,
  outcome = sample(c(rep(0, 89), rep(1, 11)))
)
observation_table <- tibble::tibble(
  group = sample(1:100, 1e5, replace = TRUE),
  observation = 1:1e5
)
sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
group_vfold_cv(sample_data, group, v = 5, strata = outcome, balance = "observations", pool = 0.1)
#> # Group 5-fold cross-validation 
#> # A tibble: 5 × 2
#>   splits                id       
#>   <list>                <chr>    
#> 1 <split [79958/20042]> Resample1
#> 2 <split [80731/19269]> Resample2
#> 3 <split [79898/20102]> Resample3
#> 4 <split [79299/20701]> Resample4
#> 5 <split [80114/19886]> Resample5

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_vfold_cv(sample_data, group, v = 5, strata = outcome, balance = "observations", pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_vfold_cv(sample_data, group, v = 5, balance = "observations")
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.10 - strata_rate))
#> [1] 0.009782044
mean(abs(0.10 - base_rate))
#> [1] 0.01529062
```

<sup>Created on 2022-09-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

I'm not 100% convinced this is the right way to do things; let me know if anything here seems wonky.

Addresses #317 (I'll say "fixed" when we have balance_prop as well).