### PR TITLE
Implement balance_prop_strata() (Fixes #317)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # rsample (development version)
 
-* `group_vfold_cv()` now supports stratification. Strata must be constant within each group (#317, #360, #363, #364).
+* All grouped resampling functions (`group_vfold_cv()`, `group_mc_cv()`, `group_initial_split()` and `group_validation_split()`, and `group_bootstraps()`) now support stratification. Strata must be constant within each group (#317, #360, #363, #364, #365).
 
 * `group_bootstraps()` now warns if resampling returns any empty assessment sets (previously had been an error) (#356) (#357).
 

--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -98,16 +98,27 @@ testing <- function(x) assessment(x)
 #' @inheritParams make_groups
 #' @rdname initial_split
 #' @export
-group_initial_split <- function(data, group, prop = 3 / 4, ...) {
+group_initial_split <- function(data, group, prop = 3 / 4, ..., strata = NULL, pool = 0.1) {
 
-  res <-
-    group_mc_cv(
-      data = data,
-      group = {{ group }},
-      prop = prop,
-      times = 1,
-      ...
-    )
+  if (missing(strata)) {
+    res <- group_mc_cv(
+        data = data,
+        group = {{ group }},
+        prop = prop,
+        times = 1,
+        ...
+      )
+  } else {
+    res <- group_mc_cv(
+        data = data,
+        group = {{ group }},
+        prop = prop,
+        times = 1,
+        ...,
+        strata = {{ strata }},
+        pool = pool
+      )
+  }
   res <- res$splits[[1]]
   class(res) <- c("group_initial_split", "initial_split", class(res))
   res

--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -179,6 +179,14 @@ balance_observations_strata <- function(data_ind, v, ...) {
 
   target_per_fold <- 1 / v
 
+  # This is the core difference between stratification and not:
+  #
+  # Without stratification, data_ind is broken into v groups,
+  # which are roughly balanced based on the number of observations
+  #
+  # With strata, data_ind is split up by strata, and then each _split_
+  # is broken into v groups (which are then combined with the other strata);
+  # the balancing for each fold is done separately inside each strata "split"
   data_splits <- split_unnamed(data_ind, data_ind[["..strata"]])
   freq_table <- purrr::map_dfr(
     data_splits,
@@ -252,6 +260,14 @@ balance_prop <- function(prop, data_ind, v, replace = FALSE, ...) {
 balance_prop_strata <- function(prop, data_ind, v, replace = FALSE, ...) {
   rlang::check_dots_empty()
 
+  # This is the core difference between stratification and not:
+  #
+  # Without stratification, `prop`% of `data_ind` is sampled `v` times;
+  # the resampling is done with the entire set of groups
+  #
+  # With strata, data_ind is split up by strata, and then each _split_
+  # has `prop`% of `data_ind` is sampled `v` times;
+  # the resampling for each iteration is done inside each strata "split"
   data_splits <- split_unnamed(data_ind, data_ind[["..strata"]])
   folds_by_strata <- purrr::map(
     data_splits,

--- a/R/printing.R
+++ b/R/printing.R
@@ -90,7 +90,7 @@ pretty.group_validation_split <- function(x, ...) {
     ") "
   )
   if (has_strata(details)) {
-    res <- paste(res, "using stratification")
+    res <- paste0(res, "using stratification")
   }
   res
 }
@@ -175,6 +175,10 @@ pretty.group_mc_cv <- function(x, ...) {
     details$times,
     " resamples "
   )
+
+  if (has_strata(details)) {
+    res <- paste0(res, "using stratification")
+  }
 
   res
 }

--- a/man/group_bootstraps.Rd
+++ b/man/group_bootstraps.Rd
@@ -4,7 +4,15 @@
 \alias{group_bootstraps}
 \title{Group Bootstraps}
 \usage{
-group_bootstraps(data, group, times = 25, apparent = FALSE, ...)
+group_bootstraps(
+  data,
+  group,
+  times = 25,
+  apparent = FALSE,
+  ...,
+  strata = NULL,
+  pool = 0.1
+)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -21,6 +29,15 @@ some estimators used by the \code{summary} function that require the apparent
 error rate.}
 
 \item{...}{Not currently used.}
+
+\item{strata}{A variable in \code{data} (single character or name) used to conduct
+stratified sampling. When not \code{NULL}, each resample is created within the
+stratification variable. Numeric \code{strata} are binned into quartiles.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 }
 \value{
 An tibble with classes \code{group_bootstraps} \code{bootstraps}, \code{rset},

--- a/man/group_mc_cv.Rd
+++ b/man/group_mc_cv.Rd
@@ -4,7 +4,15 @@
 \alias{group_mc_cv}
 \title{Group Monte Carlo Cross-Validation}
 \usage{
-group_mc_cv(data, group, prop = 3/4, times = 25, ...)
+group_mc_cv(
+  data,
+  group,
+  prop = 3/4,
+  times = 25,
+  ...,
+  strata = NULL,
+  pool = 0.1
+)
 }
 \arguments{
 \item{data}{A data frame.}
@@ -18,6 +26,15 @@ assessment set within a fold.}
 \item{times}{The number of times to repeat the sampling.}
 
 \item{...}{Not currently used.}
+
+\item{strata}{A variable in \code{data} (single character or name) used to conduct
+stratified sampling. When not \code{NULL}, each resample is created within the
+stratification variable. Numeric \code{strata} are binned into quartiles.}
+
+\item{pool}{A proportion of data used to determine if a particular group is
+too small and should be pooled into another group. We do not recommend
+decreasing this argument below its default of 0.1 because of the dangers
+of stratifying groups that are too small.}
 }
 \value{
 A tibble with classes \code{group_mc_cv},

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -16,7 +16,7 @@ training(x)
 
 testing(x)
 
-group_initial_split(data, group, prop = 3/4, ...)
+group_initial_split(data, group, prop = 3/4, ..., strata = NULL, pool = 0.1)
 }
 \arguments{
 \item{data}{A data frame.}

--- a/man/validation_split.Rd
+++ b/man/validation_split.Rd
@@ -10,7 +10,7 @@ validation_split(data, prop = 3/4, strata = NULL, breaks = 4, pool = 0.1, ...)
 
 validation_time_split(data, prop = 3/4, lag = 0, ...)
 
-group_validation_split(data, group, prop = 3/4, ...)
+group_validation_split(data, group, prop = 3/4, ..., strata = NULL, pool = 0.1)
 }
 \arguments{
 \item{data}{A data frame.}

--- a/tests/testthat/_snaps/boot.md
+++ b/tests/testthat/_snaps/boot.md
@@ -1,3 +1,17 @@
+# grouping -- strata
+
+    Code
+      sizes4
+    Output
+      # A tibble: 5 x 5
+        analysis assessment     n     p id        
+           <int>      <int> <int> <int> <chr>     
+      1    49669      18552 50000     3 Bootstrap1
+      2    49943      17429 50000     3 Bootstrap2
+      3    50133      16350 50000     3 Bootstrap3
+      4    50314      18071 50000     3 Bootstrap4
+      5    50253      17830 50000     3 Bootstrap5
+
 # bad args
 
     Code

--- a/tests/testthat/_snaps/mc.md
+++ b/tests/testthat/_snaps/mc.md
@@ -28,6 +28,20 @@
       ! Some assessment sets contained zero rows
       i Consider using a non-grouped resampling method
 
+# grouping -- strata
+
+    Code
+      sizes4
+    Output
+      # A tibble: 5 x 5
+        analysis assessment     n     p id       
+           <int>      <int> <int> <int> <chr>    
+      1    37939      12061 50000     3 Resample1
+      2    37063      12937 50000     3 Resample2
+      3    37178      12822 50000     3 Resample3
+      4    37950      12050 50000     3 Resample4
+      5    37585      12415 50000     3 Resample5
+
 # grouping - printing
 
     Code

--- a/tests/testthat/_snaps/validation.md
+++ b/tests/testthat/_snaps/validation.md
@@ -25,6 +25,16 @@
       Error in `validation_time_split()`:
       ! `lag` must be less than or equal to the number of training observations.
 
+# grouping -- strata
+
+    Code
+      sizes4
+    Output
+      # A tibble: 1 x 5
+        analysis assessment     n     p id        
+           <int>      <int> <int> <int> <chr>     
+      1    37074      12926 50000     3 validation
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -81,6 +81,25 @@
     Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common stratum.
     i Set `v` explicitly to override this warning.
 
+---
+
+    Code
+      sizes5
+    Output
+      # A tibble: 5 x 5
+        analysis assessment      n     p id       
+           <int>      <int>  <int> <int> <chr>    
+      1    80096      19904 100000     3 Resample1
+      2    79962      20038 100000     3 Resample2
+      3    79928      20072 100000     3 Resample3
+      4    80058      19942 100000     3 Resample4
+      5    79956      20044 100000     3 Resample5
+
+---
+
+    Leaving `v = NULL` while using stratification will set `v` to the number of groups present in the least common stratum.
+    i Set `v` explicitly to override this warning.
+
 # grouping -- printing
 
     Code

--- a/tests/testthat/test-boot.R
+++ b/tests/testthat/test-boot.R
@@ -101,6 +101,44 @@ test_that("strata", {
   expect_equal(res5, warpbreaks)
 })
 
+test_that("grouping -- strata", {
+  set.seed(11)
+
+  n_common_class <- 70
+  n_rare_class <- 30
+
+  group_table <- tibble(
+    group = 1:100,
+    outcome = sample(c(rep(0, n_common_class), rep(1, n_rare_class)))
+  )
+  observation_table <- tibble(
+    group = sample(1:100, 5e4, replace = TRUE),
+    observation = 1:5e4
+  )
+  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  rs4 <- group_bootstraps(sample_data, group, times = 5, strata = outcome)
+  sizes4 <- dim_rset(rs4)
+  expect_snapshot(sizes4)
+
+  rate <- purrr::map_dbl(
+    rs4$splits,
+    function(x) {
+      dat <- as.data.frame(x)$outcome
+      mean(dat == "1")
+    }
+  )
+  expect_equal(mean(rate), 0.3, tolerance = 1e-2)
+
+  good_holdout <- purrr::map_lgl(
+    rs4$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+
+})
+
 
 test_that("bad args", {
   expect_error(bootstraps(warpbreaks, strata = warpbreaks$tension))

--- a/tests/testthat/test-initial.R
+++ b/tests/testthat/test-initial.R
@@ -74,6 +74,28 @@ test_that("`prop` computes the proportion for analysis (#217)", {
   }
 })
 
+test_that("grouping -- strata", {
+  set.seed(11)
+
+  n_common_class <- 70
+  n_rare_class <- 30
+
+  group_table <- tibble(
+    group = 1:100,
+    outcome = sample(c(rep(0, n_common_class), rep(1, n_rare_class)))
+  )
+  observation_table <- tibble(
+    group = sample(1:100, 5e4, replace = TRUE),
+    observation = 1:5e4
+  )
+  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  rs4 <- group_initial_split(sample_data, group, strata = outcome)
+  expect_equal(mean(as.data.frame(rs4)$outcome == 1), 0.3, tolerance = 1e-2)
+
+  expect_identical(length(intersect(rs4$in_ind, rs4$out_id)), 0L)
+
+})
+
 test_that("`prop` computes the proportion for group analysis", {
   rs1 <- group_initial_split(dat1, c, prop = 1 / 2)
   expect_equal(class(rs1), c("group_initial_split", "initial_split", "grouped_mc_split", "mc_split", "rsplit"))

--- a/tests/testthat/test-mc.R
+++ b/tests/testthat/test-mc.R
@@ -125,6 +125,44 @@ test_that("grouping - default param", {
 
 })
 
+test_that("grouping -- strata", {
+  set.seed(11)
+
+  n_common_class <- 70
+  n_rare_class <- 30
+
+  group_table <- tibble(
+    group = 1:100,
+    outcome = sample(c(rep(0, n_common_class), rep(1, n_rare_class)))
+  )
+  observation_table <- tibble(
+    group = sample(1:100, 5e4, replace = TRUE),
+    observation = 1:5e4
+  )
+  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  rs4 <- group_mc_cv(sample_data, group, times = 5, strata = outcome)
+  sizes4 <- dim_rset(rs4)
+  expect_snapshot(sizes4)
+
+  rate <- purrr::map_dbl(
+    rs4$splits,
+    function(x) {
+      dat <- as.data.frame(x)$outcome
+      mean(dat == "1")
+    }
+  )
+  expect_equal(mean(rate), 0.3, tolerance = 1e-2)
+
+  good_holdout <- purrr::map_lgl(
+    rs4$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+
+})
+
 test_that("grouping - tibble input", {
   warpbreaks2 <- tibble::as_tibble(warpbreaks)
   set.seed(11)

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -93,18 +93,30 @@ test_that("reshuffle_rset is working", {
   )
   grouped_strata <- names(supported_subclasses)[grouped_strata]
 
+  set.seed(11)
+
+  group_table <- tibble::tibble(
+    group = 1:100,
+    outcome = sample(c(rep(0, 89), rep(1, 11)))
+  )
+  observation_table <- tibble::tibble(
+    group = sample(1:100, 5e4, replace = TRUE),
+    observation = 1:5e4
+  )
+  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+
   for (i in seq_along(grouped_strata)) {
     # Fit those functions with non-default arguments:
     set.seed(123)
-    resample <- do.call(
-      grouped_strata[i],
-      list(
-        data = cbind(test_data(), z = rep(1:5, each = 10)),
-        group = "y",
-        strata = "z",
-        breaks = 2,
-        pool = 0.2,
-        v = 2
+    resample <- suppressWarnings(
+      do.call(
+        grouped_strata[i],
+        list(
+          data = sample_data,
+          group = "group",
+          strata = "outcome",
+          pool = 0.2
+        )
       )
     )
     # Reshuffle them under the same seed to ensure they're identical


### PR DESCRIPTION
This PR fixes #317 by implementing `balance_prop_strata()` and adding `strata = NULL, prop = 0.1` to the relevant grouped resampling functions. As before, these arguments are after `...` to allow for future expansion (specifically for if `breaks` ever gets implemented). 

``` r
library(rsample)
set.seed(11)

group_table <- tibble::tibble(
  group = 1:100,
  outcome = sample(c(rep(0, 89), rep(1, 11)))
)
observation_table <- tibble::tibble(
  group = sample(1:100, 1e5, replace = TRUE),
  observation = 1:1e5
)
sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
group_mc_cv(sample_data, group, strata = outcome, pool = 0.1)
#> # Group Monte Carlo cross-validation (0.75/0.25) with 25 resamples using stratification 
#> # A tibble: 25 × 2
#>    splits                id        
#>    <list>                <chr>     
#>  1 <split [74791/25209]> Resample01
#>  2 <split [74733/25267]> Resample02
#>  3 <split [75219/24781]> Resample03
#>  4 <split [75040/24960]> Resample04
#>  5 <split [75013/24987]> Resample05
#>  6 <split [75142/24858]> Resample06
#>  7 <split [74945/25055]> Resample07
#>  8 <split [75121/24879]> Resample08
#>  9 <split [74891/25109]> Resample09
#> 10 <split [74934/25066]> Resample10
#> # … with 15 more rows
group_validation_split(sample_data, group, strata = outcome, pool = 0.1)
#> # Group Validation Set Split (0.75/0.25) using stratification 
#> # A tibble: 1 × 2
#>   splits                id        
#>   <list>                <chr>     
#> 1 <split [74886/25114]> validation
group_initial_split(sample_data, group, strata = outcome, pool = 0.1)
#> <Training/Testing/Total>
#> <74869/25131/100000>
group_bootstraps(sample_data, group, strata = outcome, pool = 0.1)
#> # Group bootstrap sampling using stratification 
#> # A tibble: 25 × 2
#>    splits                 id         
#>    <list>                 <chr>      
#>  1 <split [100554/34134]> Bootstrap01
#>  2 <split [100019/37058]> Bootstrap02
#>  3 <split [99577/41119]>  Bootstrap03
#>  4 <split [99862/39010]>  Bootstrap04
#>  5 <split [100037/34010]> Bootstrap05
#>  6 <split [100000/37967]> Bootstrap06
#>  7 <split [100273/36879]> Bootstrap07
#>  8 <split [99922/31872]>  Bootstrap08
#>  9 <split [99863/36441]>  Bootstrap09
#> 10 <split [100209/38823]> Bootstrap10
#> # … with 15 more rows

# mc_cv

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_mc_cv(sample_data, group, strata = outcome, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_mc_cv(sample_data, group, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.10 - strata_rate))
#> [1] 0.006504722
mean(abs(0.10 - base_rate))
#> [1] 0.01725373

# validation_split

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_validation_split(sample_data, group, strata = outcome, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_validation_split(sample_data, group, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.10 - strata_rate))
#> [1] 0.006540856
mean(abs(0.10 - base_rate))
#> [1] 0.01639703


# initial_split

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_initial_split(sample_data, group, strata = outcome, pool = 0.1)
    mean(as.data.frame(rs4)$outcome == "1")
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_initial_split(sample_data, group, pool = 0.1)
    mean(as.data.frame(rs4)$outcome == "1")
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.10 - strata_rate))
#> [1] 0.006545343
mean(abs(0.10 - base_rate))
#> [1] 0.01699527

# bootstraps

strata_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_bootstraps(sample_data, group, strata = outcome, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

base_rate <- purrr::map(
  1:100,
  \(x) {
    rs4 <- group_bootstraps(sample_data, group, pool = 0.1)
    purrr::map_dbl(
      rs4$splits,
      function(x) {
        dat <- as.data.frame(x)$outcome
        mean(dat == "1")
      }
    )
  }
) |> unlist()

# Mean absolute error of strata proportions, versus expected
mean(abs(0.10 - strata_rate))
#> [1] 0.009791294
mean(abs(0.10 - base_rate))
#> [1] 0.02536413
```

<sup>Created on 2022-09-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>