### PR TITLE
remove README.md from .Rbuildignore

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -2,7 +2,6 @@
 ^\.Rproj\.user$
 ^\.travis\.yml$
 README.Rmd
-README.md
 README.html
 ^docs$
 ^_pkgdown\.yml$


### PR DESCRIPTION
This PR removes `README.md` from `.Rbuildignore` making it so it will show up on CRAN and within the Package Manager UI.