### PR TITLE
use vec_detect_missing instead of vc_equal_na

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Imports:
     tibble,
     tidyr,
     tidyselect,
-    vctrs (>= 0.3.0)
+    vctrs (>= 0.5.0)
 Suggests: 
     broom,
     covr,

--- a/R/slide.R
+++ b/R/slide.R
@@ -552,8 +552,8 @@ check_skip <- function(x) {
 compute_complete_indices <- function(id_in, id_out) {
   # Remove where either list has a `NULL` element.
   # These are incomplete windows.
-  id_in_na <- vctrs::vec_equal_na(id_in)
-  id_out_na <- vctrs::vec_equal_na(id_out)
+  id_in_na <- vctrs::vec_detect_missing(id_in)
+  id_out_na <- vctrs::vec_detect_missing(id_out)
 
   id_either_na <- id_in_na | id_out_na
 


### PR DESCRIPTION
> [vec_equal_na()](https://vctrs.r-lib.org/reference/vec_equal_na.html) has been renamed to [vec_detect_missing()](https://vctrs.r-lib.org/reference/missing.html) to align better with vctrs naming conventions. [vec_equal_na()](https://vctrs.r-lib.org/reference/vec_equal_na.html) will stick around for a few minor versions, but has been formally soft-deprecated ([#1672](https://github.com/r-lib/vctrs/issues/1672)).