### PR TITLE
Add repeats to clustering_cv()

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -103,7 +103,7 @@ clustering_cv <- function(data,
   cv_att <- list(
     v = v,
     vars = names(vars),
-    repeats = 1,
+    repeats = repeats,
     distance_function = distance_function,
     cluster_function = cluster_function
   )

--- a/R/clustering.R
+++ b/R/clustering.R
@@ -28,9 +28,9 @@
 #' `nrow(data)`, with each element of the vector corresponding to the matching
 #' row of the data frame.
 #'
-#' @param data A data frame to split into folds.
+#' @inheritParams vfold_cv
 #' @param vars A vector of bare variable names to use to cluster the data.
-#' @param v The number of partitions of the data set.
+#' @param repeats The number of times to repeat the clustered partitioning.
 #' @param distance_function Which function should be used for distance calculations?
 #' Defaults to [stats::dist()]. You can also provide your own
 #' function; see `Details`.
@@ -53,6 +53,7 @@
 clustering_cv <- function(data,
                           vars,
                           v = 10,
+                          repeats = 1,
                           distance_function = "dist",
                           cluster_function = c("kmeans", "hclust"),
                           ...) {
@@ -65,15 +66,35 @@ clustering_cv <- function(data,
     rlang::abort("`vars` are required and must be variables in `data`.")
   }
   vars <- data[vars]
-  dists <- rlang::exec(distance_function, vars)
 
-  split_objs <- clustering_splits(
-    data = data,
-    dists = dists,
-    v = v,
-    cluster_function = cluster_function,
-    ...
-  )
+  if (repeats == 1) {
+    dists <- rlang::exec(distance_function, vars)
+    split_objs <- clustering_splits(
+      data = data,
+      dists = dists,
+      v = v,
+      cluster_function = cluster_function,
+      ...
+    )
+  } else {
+    for (i in 1:repeats) {
+      dists <- rlang::exec(distance_function, vars)
+      tmp <- clustering_splits(
+        data = data,
+        dists = dists,
+        v = v,
+        cluster_function = cluster_function,
+        ...
+      )
+      tmp$id2 <- tmp$id
+      tmp$id <- names0(repeats, "Repeat")[i]
+      split_objs <- if (i == 1) {
+        tmp
+      } else {
+        rbind(split_objs, tmp)
+      }
+    }
+  }
 
   split_objs$splits <- map(split_objs$splits, rm_out)
 

--- a/R/compat-vctrs-helpers.R
+++ b/R/compat-vctrs-helpers.R
@@ -140,7 +140,7 @@ delayedAssign("rset_subclasses", {
         manual_rset            = manual_rset(list(initial_time_split(test_data()), initial_time_split(test_data())), c("ID1", "ID2")),
         apparent               = apparent(test_data()),
         permutations           = permutations(test_data(), y),
-        clustering_cv          = clustering_cv(test_data(), y)
+        clustering_cv          = clustering_cv(test_data(), y, repeats = 2)
       )
     )
   } else {

--- a/man/clustering_cv.Rd
+++ b/man/clustering_cv.Rd
@@ -8,17 +8,20 @@ clustering_cv(
   data,
   vars,
   v = 10,
+  repeats = 1,
   distance_function = "dist",
   cluster_function = c("kmeans", "hclust"),
   ...
 )
 }
 \arguments{
-\item{data}{A data frame to split into folds.}
+\item{data}{A data frame.}
 
 \item{vars}{A vector of bare variable names to use to cluster the data.}
 
 \item{v}{The number of partitions of the data set.}
+
+\item{repeats}{The number of times to repeat the clustered partitioning.}
 
 \item{distance_function}{Which function should be used for distance calculations?
 Defaults to \code{\link[stats:dist]{stats::dist()}}. You can also provide your own

--- a/tests/testthat/_snaps/clustering.md
+++ b/tests/testthat/_snaps/clustering.md
@@ -21,8 +21,8 @@
     Output
       # 2-cluster cross-validation 
       # A tibble: 2 x 2
-        splits          id   
-        <list>          <chr>
-      1 <split [10/10]> Fold1
-      2 <split [10/10]> Fold2
+        splits         id   
+        <list>         <chr>
+      1 <split [5/15]> Fold1
+      2 <split [15/5]> Fold2
 

--- a/tests/testthat/_snaps/compat-vctrs.md
+++ b/tests/testthat/_snaps/compat-vctrs.md
@@ -208,8 +208,10 @@
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
 
 # vec_cbind() returns a bare tibble
 
@@ -1013,13 +1015,17 @@
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
 
 ---
 
@@ -1029,13 +1035,17 @@
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
 
 ---
 
@@ -1045,6 +1055,8 @@
       New names:
       * `splits` -> `splits...1`
       * `id` -> `id...2`
-      * `splits` -> `splits...3`
-      * `id` -> `id...4`
+      * `id2` -> `id2...3`
+      * `splits` -> `splits...4`
+      * `id` -> `id...5`
+      * `id2` -> `id2...6`
 

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -45,6 +45,7 @@ test_that("bad args", {
 })
 
 test_that("printing", {
+  set.seed(11)
   expect_snapshot(clustering_cv(dat1, c, v = 2))
 })
 

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -17,6 +17,26 @@ test_that("default param", {
   expect_true(all(good_holdout))
 })
 
+test_that("repeated", {
+  set.seed(11)
+  rs2 <- clustering_cv(dat1, c, v = 2, repeats = 4)
+  sizes2 <- dim_rset(rs2)
+
+  same_data <-
+    purrr::map_lgl(rs2$splits, function(x) {
+      all.equal(x$data, dat1)
+    })
+  expect_true(all(same_data))
+
+  good_holdout <- purrr::map_lgl(
+    rs2$splits,
+    function(x) {
+      length(intersect(x$in_ind, x$out_id)) == 0
+    }
+  )
+  expect_true(all(good_holdout))
+})
+
 test_that("bad args", {
   expect_snapshot_error(clustering_cv(dat1))
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, v = -500))


### PR DESCRIPTION
Fixes #372.

``` r
rsample::clustering_cv(
  modeldata::ames, 
  Sale_Price, 
  v = 2,
  repeats = 4
)
#> # 2-cluster cross-validation 
#> # A tibble: 8 × 3
#>   splits             id      id2  
#>   <list>             <chr>   <chr>
#> 1 <split [472/2458]> Repeat1 Fold1
#> 2 <split [2458/472]> Repeat1 Fold2
#> 3 <split [2458/472]> Repeat2 Fold1
#> 4 <split [472/2458]> Repeat2 Fold2
#> 5 <split [2458/472]> Repeat3 Fold1
#> 6 <split [472/2458]> Repeat3 Fold2
#> 7 <split [472/2458]> Repeat4 Fold1
#> 8 <split [2458/472]> Repeat4 Fold2
```

<sup>Created on 2022-11-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>