### PR TITLE
Error better on bad values for `repeats`

### DIFF
--- a/R/clustering.R
+++ b/R/clustering.R
@@ -57,6 +57,8 @@ clustering_cv <- function(data,
                           distance_function = "dist",
                           cluster_function = c("kmeans", "hclust"),
                           ...) {
+  check_repeats(repeats)
+
   if (!rlang::is_function(cluster_function)) {
     cluster_function <- rlang::arg_match(cluster_function)
   }

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -71,6 +71,7 @@ vfold_cv <- function(data, v = 10, repeats = 1,
   }
 
   strata_check(strata, data)
+  check_repeats(repeats)
 
   if (repeats == 1) {
     split_objs <- vfold_splits(
@@ -211,6 +212,7 @@ vfold_splits <- function(data, v = 10, strata = NULL, breaks = 4, pool = 0.1) {
 #' @export
 group_vfold_cv <- function(data, group = NULL, v = NULL, repeats = 1, balance = c("groups", "observations"), ..., strata = NULL, pool = 0.1) {
 
+  check_repeats(repeats)
   group <- validate_group({{ group }}, data)
   balance <- rlang::arg_match(balance)
 
@@ -353,4 +355,10 @@ check_grouped_strata <- function(group, strata, pool, data) {
   }
 
   strata
+}
+
+check_repeats <- function(repeats, call = rlang::caller_env()) {
+  if (!is.numeric(repeats) || length(repeats) != 1 || repeats < 1) {
+    rlang::abort("`repeats` must be a single positive integer", call = call)
+  }
 }

--- a/tests/testthat/_snaps/clustering.md
+++ b/tests/testthat/_snaps/clustering.md
@@ -14,6 +14,14 @@
 
     `cluster_function` must be one of "kmeans" or "hclust", not "not an option".
 
+---
+
+    `repeats` must be a single positive integer
+
+---
+
+    `repeats` must be a single positive integer
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -19,6 +19,14 @@
 
     Repeated resampling when `v` is 150 would create identical resamples
 
+---
+
+    `repeats` must be a single positive integer
+
+---
+
+    `repeats` must be a single positive integer
+
 # printing
 
     Code

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -42,6 +42,8 @@ test_that("bad args", {
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, v = -500))
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, v = 500))
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, cluster_function = "not an option"))
+  expect_snapshot_error(clustering_cv(Orange, repeats = 0))
+  expect_snapshot_error(clustering_cv(Orange, repeats = NULL))
 })
 
 test_that("printing", {

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -81,6 +81,8 @@ test_that("bad args", {
   expect_snapshot_error(vfold_cv(iris, v = -500))
   expect_snapshot_error(vfold_cv(iris, v = 500))
   expect_snapshot_error(vfold_cv(iris, v = 150, repeats = 2))
+  expect_snapshot_error(vfold_cv(Orange, repeats = 0))
+  expect_snapshot_error(vfold_cv(Orange, repeats = NULL))
 })
 
 test_that("printing", {


### PR DESCRIPTION
closes #370

``` r
library(rsample)

vfold_cv(Orange, repeats = 0)
#> Error in `vfold_cv()`:
#> ! `repeats` must be a single positive integer

#> Backtrace:
#>     ▆
#>  1. └─rsample::vfold_cv(Orange, repeats = 0)
#>  2.   └─rsample:::check_repeats(repeats) at rsample/R/vfold.R:74:2
#>  3.     └─rlang::abort("`repeats` must be a single positive integer", call = call) at rsample/R/vfold.R:362:4
vfold_cv(Orange, repeats = NULL)
#> Error in `vfold_cv()`:
#> ! `repeats` must be a single positive integer

#> Backtrace:
#>     ▆
#>  1. └─rsample::vfold_cv(Orange, repeats = NULL)
#>  2.   └─rsample:::check_repeats(repeats) at rsample/R/vfold.R:74:2
#>  3.     └─rlang::abort("`repeats` must be a single positive integer", call = call) at rsample/R/vfold.R:362:4
```

<sup>Created on 2022-11-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>