### PR TITLE
Error for `v` < 2 in `vfold_cv()`, `group_cv()`, and `clustering_cv()`

### DIFF
--- a/R/vfold.R
+++ b/R/vfold.R
@@ -332,7 +332,7 @@ add_vfolds <- function(x, v) {
 }
 
 check_v <- function(v, max_v, rows = "rows", call = rlang::caller_env()) {
-  if (!is.numeric(v) || length(v) != 1 || v < 0) {
+  if (!is.numeric(v) || length(v) != 1 || v < 1) {
     rlang::abort("`v` must be a single positive integer", call = call)
   } else if (v > max_v) {
     rlang::abort(

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -332,8 +332,8 @@ add_vfolds <- function(x, v) {
 }
 
 check_v <- function(v, max_v, rows = "rows", call = rlang::caller_env()) {
-  if (!is.numeric(v) || length(v) != 1 || v < 1) {
-    rlang::abort("`v` must be a single positive integer", call = call)
+  if (!is.numeric(v) || length(v) != 1 || v < 2) {
+    rlang::abort("`v` must be a single positive integer greater than 1", call = call)
   } else if (v > max_v) {
     rlang::abort(
       glue::glue("The number of {rows} is less than `v = {v}`"), call = call

--- a/tests/testthat/_snaps/clustering.md
+++ b/tests/testthat/_snaps/clustering.md
@@ -4,7 +4,7 @@
 
 ---
 
-    `v` must be a single positive integer
+    `v` must be a single positive integer greater than 1
 
 ---
 
@@ -13,6 +13,14 @@
 ---
 
     `cluster_function` must be one of "kmeans" or "hclust", not "not an option".
+
+---
+
+    Code
+      clustering_cv(Orange, v = 1, vars = "Tree")
+    Condition
+      Error in `clustering_cv()`:
+      ! `v` must be a single positive integer greater than 1
 
 ---
 

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -13,6 +13,14 @@
 
 ---
 
+    `v` must be a single positive integer
+
+---
+
+    `v` must be a single positive integer
+
+---
+
     The number of rows is less than `v = 500`
 
 ---

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -9,15 +9,15 @@
 
 # bad args
 
-    `v` must be a single positive integer
+    `v` must be a single positive integer greater than 1
 
 ---
 
-    `v` must be a single positive integer
+    `v` must be a single positive integer greater than 1
 
 ---
 
-    `v` must be a single positive integer
+    `v` must be a single positive integer greater than 1
 
 ---
 
@@ -62,6 +62,14 @@
 ---
 
     Repeated resampling when `v` is `NULL` would create identical resamples
+
+---
+
+    Code
+      group_vfold_cv(Orange, v = 1, group = "Tree")
+    Condition
+      Error in `group_vfold_cv()`:
+      ! `v` must be a single positive integer greater than 1
 
 # grouping -- other balance methods
 

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -42,6 +42,7 @@ test_that("bad args", {
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, v = -500))
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, v = 500))
   expect_snapshot_error(clustering_cv(iris, Sepal.Length, cluster_function = "not an option"))
+  expect_snapshot(error = TRUE, clustering_cv(Orange, v = 1, vars = "Tree"))
   expect_snapshot_error(clustering_cv(Orange, repeats = 0))
   expect_snapshot_error(clustering_cv(Orange, repeats = NULL))
 })

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -79,6 +79,8 @@ test_that("bad args", {
   expect_error(vfold_cv(iris, strata = iris$Species))
   expect_error(vfold_cv(iris, strata = c("Species", "Sepal.Width")))
   expect_snapshot_error(vfold_cv(iris, v = -500))
+  expect_snapshot_error(vfold_cv(iris, v = 0))
+  expect_snapshot_error(vfold_cv(iris, v = NULL))
   expect_snapshot_error(vfold_cv(iris, v = 500))
   expect_snapshot_error(vfold_cv(iris, v = 150, repeats = 2))
   expect_snapshot_error(vfold_cv(Orange, repeats = 0))

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -79,7 +79,7 @@ test_that("bad args", {
   expect_error(vfold_cv(iris, strata = iris$Species))
   expect_error(vfold_cv(iris, strata = c("Species", "Sepal.Width")))
   expect_snapshot_error(vfold_cv(iris, v = -500))
-  expect_snapshot_error(vfold_cv(iris, v = 0))
+  expect_snapshot_error(vfold_cv(iris, v = 1))
   expect_snapshot_error(vfold_cv(iris, v = NULL))
   expect_snapshot_error(vfold_cv(iris, v = 500))
   expect_snapshot_error(vfold_cv(iris, v = 150, repeats = 2))
@@ -112,6 +112,7 @@ test_that("grouping -- bad args", {
   expect_error(group_vfold_cv(warpbreaks, group = "tension", v = 10))
   expect_snapshot_error(group_vfold_cv(dat1, c, v = 4, repeats = 4))
   expect_snapshot_error(group_vfold_cv(dat1, c, repeats = 4))
+  expect_snapshot(error = TRUE, group_vfold_cv(Orange, v = 1, group = "Tree"))
 })
 
 


### PR DESCRIPTION
Instead of 

``` r
library(rsample)

vfold_cv(Orange, v = 0)
#> #  0-fold cross-validation 
#> # A tibble: 2 × 2
#>   splits          id   
#>   <list>          <chr>
#> 1 <split [18/17]> Fold1
#> 2 <split [17/18]> Fold2

group_vfold_cv(Orange, v = 0, group = "Tree")
#> # Group 0-fold cross-validation 
#> # A tibble: 0 × 2
#> # … with 2 variables: splits <list>, id <chr>

clustering_cv(Orange, v = 0, vars = "Tree")
#> Error: number of cluster centres must lie between 1 and nrow(x)
```

<sup>Created on 2022-11-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

now this


``` r
library(rsample)

vfold_cv(Orange, v = 0)
#> Error in `vfold_cv()`:
#> ! `v` must be a single positive integer greater than 1

group_vfold_cv(Orange, v = 0, group = "Tree")
#> Error in `group_vfold_cv()`:
#> ! `v` must be a single positive integer greater than 1

clustering_cv(Orange, v = 1, vars = "Tree")
#> Error in `clustering_cv()`:
#> ! `v` must be a single positive integer greater than 1
```

<sup>Created on 2022-11-18 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>