### PR TITLE
Remove overly strict test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* Removed an overly strict test in preparation for dplyr 1.1.0 (#380).
+
 * All grouped resampling functions (`group_vfold_cv()`, `group_mc_cv()`, `group_initial_split()` and `group_validation_split()`, and `group_bootstraps()`) now support stratification. Strata must be constant within each group (#317, #360, #363, #364, #365).
 
 * `group_bootstraps()` now warns if resampling returns any empty assessment sets (previously had been an error) (#356) (#357).

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -251,7 +251,6 @@ test_that("slice() drops rset class when rows are modified", {
 
 test_that("slice() keeps rset class when rows are untouched", {
   for (x in rset_subclasses) {
-    expect_s3_class_rset(slice(x))
     expect_s3_class_rset(slice(x, seq_len(nrow(x))))
   }
 })


### PR DESCRIPTION
This isn't really testing much, and is handled by the other test anyways

We are going to change `slice(df)` to drop all rows rather than keep them all. This is mainly of theoretical interest, and it makes the internal dplyr code a little simpler. https://github.com/tidyverse/dplyr/pull/6573

rsample seems to be the only package affected by this, because of an overly strict test I added while checking dplyr compatibility .