### PR TITLE
Fix assessment set for `validation_time_split()` with lags

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@
 
 * Added a new function, `clustering_cv()`, for blocked cross-validation in various predictor spaces. This is a very flexible function, taking arguments to both `distance_function` and `cluster_function`, allowing it to be used for spatial clustering as well as potentially phylogenetic and other forms of clustering (#351).
 
+* The assessment set of `validation_time_split()` now also contains the lagged observations (#376).
+
 # rsample 1.1.0
 
 * rset objects now include all parameters used to create them as attributes (#329).

--- a/R/validation_split.R
+++ b/R/validation_split.R
@@ -88,7 +88,6 @@ validation_time_split <- function(data, prop = 3 / 4, lag = 0, ...) {
   }
 
   split <- rsplit(data, 1:n_train, (n_train + 1 - lag):nrow(data))
-  split <- rm_out(split)
   class(split) <- c("val_time_split", "val_split", "rsplit")
   splits <- list(split)
 

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -60,6 +60,13 @@ test_that("default time param with lag", {
   expect_snapshot(validation_time_split(drinks, lag = 500), error = TRUE)
 })
 
+test_that("assessment set of time split includes the lag (#376)", {
+  toy_data <- data.frame(id = 1:100)
+  val_rset <- validation_time_split(toy_data, prob = 75, lag = 2)
+  dat_assess <- assessment(val_rset$splits[[1]])
+  expect_equal(dat_assess$id, 74:100)
+})
+
 test_that("default group param", {
   set.seed(11)
   rs1 <- group_validation_split(dat1, c)


### PR DESCRIPTION
Closes #376 

``` r
library(rsample)
library(dplyr)

toy_data <- data.frame(id = 1:100)
val_rset <- validation_time_split(toy_data, prob = .75, lag = 2)

# should be 76:100 plus the 2 lagged obs -> 74:100
assessment(val_rset$splits[[1]]) %>% pull(id) %>% range()
#> [1]  74 100

# done via keeping the indices for what's "out"
val_rset$splits[[1]]$out_id
#>  [1]  74  75  76  77  78  79  80  81  82  83  84  85  86  87  88  89  90  91  92
#> [20]  93  94  95  96  97  98  99 100

# which is what `inital_time_split()` does
split <- initial_time_split(toy_data, prob = .75, lag = 2)
split$out_id
#>  [1]  74  75  76  77  78  79  80  81  82  83  84  85  86  87  88  89  90  91  92
#> [20]  93  94  95  96  97  98  99 100
```

<sup>Created on 2022-12-01 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>