### PR TITLE
use testthat::skip_if_not_installed()

### DIFF
--- a/tests/testthat/test-bootci.R
+++ b/tests/testthat/test-bootci.R
@@ -14,7 +14,7 @@ bt_norm <-
   )
 
 test_that("Bootstrap estimate of mean is close to estimate of mean from normal distribution", {
-  skip_if_not_is_installed("broom")
+  skip_if_not_installed("broom")
   skip_on_cran()
   ttest <- broom::tidy(t.test(rand_nums))
   ttest_lower_conf <- broom::tidy(t.test(rand_nums, conf.level = 0.8))
@@ -82,6 +82,7 @@ test_that("Bootstrap estimate of mean is close to estimate of mean from normal d
 # ------------------------------------------------------------------------------
 
 test_that("Wrappers -- selection of multiple variables works", {
+  skip_if_not_installed("broom")
   skip_if_not_installed("modeldata")
   data("attrition", package = "modeldata")
   func <- function(split, ...) {

--- a/tests/testthat/test-bootci.R
+++ b/tests/testthat/test-bootci.R
@@ -14,7 +14,7 @@ bt_norm <-
   )
 
 test_that("Bootstrap estimate of mean is close to estimate of mean from normal distribution", {
-  skip_if_not(rlang::is_installed("broom"))
+  skip_if_not_is_installed("broom")
   skip_on_cran()
   ttest <- broom::tidy(t.test(rand_nums))
   ttest_lower_conf <- broom::tidy(t.test(rand_nums, conf.level = 0.8))
@@ -82,7 +82,7 @@ test_that("Bootstrap estimate of mean is close to estimate of mean from normal d
 # ------------------------------------------------------------------------------
 
 test_that("Wrappers -- selection of multiple variables works", {
-  skip_if_not(rlang::is_installed("modeldata"))
+  skip_if_not_installed("modeldata")
   data("attrition", package = "modeldata")
   func <- function(split, ...) {
     lm(Age ~ HourlyRate + DistanceFromHome, data = analysis(split)) %>% tidy()
@@ -232,7 +232,7 @@ test_that("bad input", {
 # ------------------------------------------------------------------------------
 
 test_that("regression intervals", {
-  skip_if_not(rlang::is_installed("broom"))
+  skip_if_not_installed("broom")
   skip_on_cran()
 
   expect_error(

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -1,5 +1,5 @@
 library(dplyr)
-skip_if_not(rlang::is_installed("withr"))
+skip_if_not_installed("withr")
 # ------------------------------------------------------------------------------
 # dplyr_reconstruct()
 

--- a/tests/testthat/test-initial.R
+++ b/tests/testthat/test-initial.R
@@ -28,7 +28,7 @@ test_that("default time param with lag", {
   expect_equal(tr1, dplyr::slice(dat1, 1:floor(nrow(dat1) * 3 / 4)))
   expect_equal(ts1, dat1[(floor(nrow(dat1) * 3 / 4) + 1 - 5):nrow(dat1), ])
 
-  skip_if_not(rlang::is_installed("modeldata"))
+  skip_if_not_installed("modeldata")
   data(drinks, package = "modeldata")
 
   # Whole numbers only

--- a/tests/testthat/test-make_groups.R
+++ b/tests/testthat/test-make_groups.R
@@ -1,5 +1,5 @@
 test_that("grouped variants have the same classes as nongrouped outputs", {
-  skip_if_not(rlang::is_installed("withr"))
+  skip_if_not_installed("withr")
   grouped_variants <- grep("^group_", names(rset_subclasses), value = TRUE)
 
   for (x in grouped_variants) {
@@ -30,7 +30,7 @@ test_that("grouped variants have the same classes as nongrouped outputs", {
 })
 
 test_that("grouped variants are consistent across R sessions", {
-  skip_if_not(rlang::is_installed("withr"))
+  skip_if_not_installed("withr")
   grouped_variants <- grep("^group_", names(rset_subclasses), value = TRUE)
 
   for (x in grouped_variants) {

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -1,5 +1,5 @@
 test_that("reverse_splits is working", {
-  skip_if_not(rlang::is_installed("withr"))
+  skip_if_not_installed("withr")
 
   reversable_subclasses <- setdiff(names(rset_subclasses), "permutations")
   reversable_subclasses <- rset_subclasses[reversable_subclasses]
@@ -35,7 +35,7 @@ test_that("reverse_splits is working", {
 
 test_that("reshuffle_rset is working", {
 
-  skip_if_not(rlang::is_installed("withr"))
+  skip_if_not_installed("withr")
   supported_subclasses <- rset_subclasses[
     setdiff(names(rset_subclasses), c("manual_rset"))
   ]

--- a/tests/testthat/test-nesting.R
+++ b/tests/testthat/test-nesting.R
@@ -93,7 +93,7 @@ test_that("rsplit labels", {
 
 # ------------------------------------------------------------------------------
 # `[`
-skip_if_not(rlang::is_installed("withr"))
+skip_if_not_installed("withr")
 test_that("can keep the rset class", {
   x <- rset_subclasses$nested_cv
   loc <- seq_len(ncol(x))

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -46,7 +46,7 @@ test_that("default time param", {
 })
 
 test_that("default time param with lag", {
-  skip_if_not(rlang::is_installed("modeldata"))
+  skip_if_not_installed("modeldata")
   data(drinks, package = "modeldata")
 
   rs1 <- validation_time_split(dat1, lag = 5)

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -44,7 +44,7 @@ test_that("repeated", {
 
 test_that("strata", {
   set.seed(11)
-  skip_if_not(rlang::is_installed("modeldata"))
+  skip_if_not_installed("modeldata")
   data("mlc_churn", package = "modeldata")
   rs3 <- vfold_cv(mlc_churn, repeats = 2, strata = "voice_mail_plan")
   sizes3 <- dim_rset(rs3)
@@ -194,7 +194,7 @@ test_that("grouping -- tibble input", {
 })
 
 test_that("grouping -- other balance methods", {
-  skip_if_not(rlang::is_installed("modeldata"))
+  skip_if_not_installed("modeldata")
   data(ames, package = "modeldata")
   set.seed(11)
   rs1 <- group_vfold_cv(


### PR DESCRIPTION
This leads to better messages in the test log (as compared to e.g. 'rlang::is_installed("withr") is not TRUE (2)')