### PR TITLE
dplyr 1.1.0 and multiple matches in joins

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,7 +22,7 @@ Depends:
     R (>= 3.4)
 Imports: 
     cli,
-    dplyr (>= 1.0.0),
+    dplyr (>= 1.1.0),
     furrr,
     generics,
     glue,

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -372,7 +372,7 @@ bca_calc <- function(stats, orig_data, alpha = 0.05, .fn, ...) {
     loo_res %>%
     dplyr::group_by(term) %>%
     dplyr::summarize(loo = mean(estimate, na.rm = TRUE)) %>%
-    dplyr::inner_join(loo_res, by = "term") %>%
+    dplyr::inner_join(loo_res, by = "term", multiple = "all") %>%
     dplyr::group_by(term) %>%
     dplyr::summarize(
       cubed = sum((loo - estimate)^3),

--- a/R/make_groups.R
+++ b/R/make_groups.R
@@ -302,7 +302,12 @@ check_prop <- function(prop, replace) {
 
 
 collapse_groups <- function(freq_table, data_ind, v) {
-  data_ind <- dplyr::left_join(data_ind, freq_table, by = c("..group" = "key"))
+  data_ind <- dplyr::left_join(
+    data_ind,
+    freq_table,
+    by = c("..group" = "key"),
+    multiple = "all"
+  )
   data_ind$..group <- data_ind$assignment
   data_ind <- data_ind[c("..index", "..group")]
 

--- a/tests/testthat/test-boot.R
+++ b/tests/testthat/test-boot.R
@@ -115,7 +115,12 @@ test_that("grouping -- strata", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
   rs4 <- group_bootstraps(sample_data, group, times = 5, strata = outcome)
   sizes4 <- dim_rset(rs4)
   expect_snapshot(sizes4)

--- a/tests/testthat/test-compat-dplyr.R
+++ b/tests/testthat/test-compat-dplyr.R
@@ -325,7 +325,7 @@ test_that("left_join() can keep rset class if rset structure is intact", {
 test_that("left_join() can lose rset class if rows are added", {
   for (x in rset_subclasses) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(left_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(left_join(x, y, by = "id", multiple = "all"))
   }
 })
 
@@ -347,7 +347,7 @@ test_that("right_join() can keep rset class if rset structure is intact", {
 test_that("right_join() can lose rset class if rows are added", {
   for (x in rset_subclasses) {
     y <- tibble(id = x$id[[1]], x = 1:2)
-    expect_s3_class_bare_tibble(right_join(x, y, by = "id"))
+    expect_s3_class_bare_tibble(right_join(x, y, by = "id", multiple = "all"))
   }
 })
 
@@ -355,7 +355,7 @@ test_that("right_join() restores to the type of first input", {
   for (x in rset_subclasses) {
     y <- tibble(id = x$id[[1]], x = 1)
     # technically rset structure is intact, but `y` is a bare tibble!
-    expect_s3_class_bare_tibble(right_join(y, x, by = "id"))
+    expect_s3_class_bare_tibble(right_join(y, x, by = "id", multiple = "all"))
   }
 })
 
@@ -451,4 +451,3 @@ test_that("bind_cols() drops the class with new rows", {
   x <- rset_subclasses$apparent
   expect_s3_class_bare_tibble(bind_cols(x, tibble(x = 1:2)))
 })
-

--- a/tests/testthat/test-initial.R
+++ b/tests/testthat/test-initial.R
@@ -88,7 +88,12 @@ test_that("grouping -- strata", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
   rs4 <- group_initial_split(sample_data, group, strata = outcome)
   expect_equal(mean(as.data.frame(rs4)$outcome == 1), 0.3, tolerance = 1e-2)
 

--- a/tests/testthat/test-initial_validation_split.R
+++ b/tests/testthat/test-initial_validation_split.R
@@ -130,7 +130,12 @@ test_that("grouped split stratified", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
 
   val_split <- group_initial_validation_split(
     sample_data,

--- a/tests/testthat/test-mc.R
+++ b/tests/testthat/test-mc.R
@@ -139,7 +139,12 @@ test_that("grouping -- strata", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
   rs4 <- group_mc_cv(sample_data, group, times = 5, strata = outcome)
   sizes4 <- dim_rset(rs4)
   expect_snapshot(sizes4)

--- a/tests/testthat/test-misc.R
+++ b/tests/testthat/test-misc.R
@@ -103,7 +103,12 @@ test_that("reshuffle_rset is working", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
 
   for (i in seq_along(grouped_strata)) {
     # Fit those functions with non-default arguments:

--- a/tests/testthat/test-validation.R
+++ b/tests/testthat/test-validation.R
@@ -103,7 +103,12 @@ test_that("grouping -- strata", {
     group = sample(1:100, 5e4, replace = TRUE),
     observation = 1:5e4
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
   rs4 <- group_validation_split(sample_data, group, strata = outcome)
   sizes4 <- dim_rset(rs4)
   expect_snapshot(sizes4)

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -243,7 +243,12 @@ test_that("grouping -- strata", {
     group = sample(1:100, 1e5, replace = TRUE),
     observation = 1:1e5
   )
-  sample_data <- dplyr::full_join(group_table, observation_table, by = "group")
+  sample_data <- dplyr::full_join(
+    group_table,
+    observation_table,
+    by = "group",
+    multiple = "all"
+  )
   rs4 <- group_vfold_cv(sample_data, group, v = 5, strata = outcome)
   sizes4 <- dim_rset(rs4)
   expect_snapshot(sizes4)


### PR DESCRIPTION
This PR adapts rsample to dplyr 1.1.0: multiple matches in joins now cause warnings unless we set `multiple = "all"`.

That argument `multiple` is new in v1.1.0 so I've also bumped the minimum version up. In other packages, prior to the CRAN release of dplyr v1.1.0, we only used that argument conditionally, e.g.
```
if (utils::packageVersion("dplyr") >= "1.0.99.9000") {
    pred <- full_join(param_key, pred, by = "group", multiple = "all")
  } else {
    pred <- full_join(param_key, pred, by = "group")
  }
```
Happy to change it to this pattern if we think we don't want to depend on v1.1.0 just yet!