### PR TITLE
Expand the grouping columns for percentile and t confidence intervals

### DIFF
--- a/R/bootci.R
+++ b/R/bootci.R
@@ -72,13 +72,14 @@ check_tidy <- function(x, std_col = FALSE) {
       x <-
         dplyr::select(x, dplyr::all_of(grp_cols), estimate, id,
                       tidyselect::one_of(std_candidates)) %>%
-        mutate(id = (id == "Apparent")) %>%
-        setNames(c("term", "estimate", "orig", "std_err"))
+        mutate(orig = (id == "Apparent")) %>%
+        update_std_err_name() %>%
+        dplyr::select(-id)
     } else {
       x <-
         dplyr::select(x, dplyr::all_of(grp_cols), estimate,
                       tidyselect::one_of(std_candidates)) %>%
-        setNames(c("term", "estimate", "std_err"))
+        update_std_err_name()
     }
   } else {
     if (has_id) {
@@ -94,6 +95,12 @@ check_tidy <- function(x, std_col = FALSE) {
   x
 }
 
+update_std_err_name <- function(x) {
+  if (any(names(x) == "std.error")) {
+    x <- dplyr::rename(x, std_err = std.error)
+  }
+  x
+}
 
 get_p0 <- function(x, alpha = 0.05) {
   orig <- x %>%

--- a/R/bootci.R
+++ b/R/bootci.R
@@ -63,28 +63,31 @@ check_tidy <- function(x, std_col = FALSE) {
   }
 
   check_tidy_names(x, std_col)
+  grp_cols <- int_group_cols(x)
 
   if (std_col) {
     std_candidates <- colnames(x) %in% std_exp
     std_candidates <- colnames(x)[std_candidates]
     if (has_id) {
       x <-
-        dplyr::select(x, term, estimate, id, tidyselect::one_of(std_candidates)) %>%
+        dplyr::select(x, dplyr::all_of(grp_cols), estimate, id,
+                      tidyselect::one_of(std_candidates)) %>%
         mutate(id = (id == "Apparent")) %>%
         setNames(c("term", "estimate", "orig", "std_err"))
     } else {
       x <-
-        dplyr::select(x, term, estimate, tidyselect::one_of(std_candidates)) %>%
+        dplyr::select(x, dplyr::all_of(grp_cols), estimate,
+                      tidyselect::one_of(std_candidates)) %>%
         setNames(c("term", "estimate", "std_err"))
     }
   } else {
     if (has_id) {
       x <-
-        dplyr::select(x, term, estimate, id) %>%
+        dplyr::select(x, dplyr::all_of(grp_cols), estimate, id) %>%
         mutate(orig = (id == "Apparent")) %>%
         dplyr::select(-id)
     } else {
-      x <- dplyr::select(x, term, estimate)
+      x <- dplyr::select(x, dplyr::all_of(grp_cols), estimate)
     }
   }
 
@@ -146,6 +149,9 @@ check_num_resamples <- function(x, B = 1000) {
 # ------------------------------------------------------------------------------
 # percentile code
 
+pctl_calcs <- function(x) {
+
+}
 
 pctl_single <- function(stats, alpha = 0.05) {
   if (all(is.na(stats))) {


### PR DESCRIPTION
For use with `tune_result` objects, this PR allows `int_pctl()` and `int_t()` to `group_by()` more columns than just `term`. 

This expands the list to `"term"`, `".config"`, `".iter"`, and `".eval_time"`.

Since this is a developer-facing change, it is undocumented (in Rd file) and I left it out of NEWS.md