### PR TITLE
make origin of validation `rset` traceable

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: rsample
 Title: General Resampling Infrastructure
-Version: 1.1.1.9000
+Version: 1.1.1.9001
 Authors@R: c(
     person("Hannah", "Frick", , "hannah@posit.co", role = c("aut", "cre"),
            comment = c(ORCID = "0000-0002-6049-5258")),

--- a/R/validation_set.R
+++ b/R/validation_set.R
@@ -33,6 +33,7 @@ validation_set <- function(split, ...) {
   class(val_split) <- c("val_split", "rsplit")
 
   val_att <- attr(split, "val_att")
+  val_att[["origin_3way"]] <- TRUE
 
   new_rset(
     splits = list(val_split),


### PR DESCRIPTION
This is prep for changes in tune to `last_fit()` and `fit_best()` 