### PR TITLE
Reorganize reference index for resampling methods

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -37,21 +37,21 @@ reference:
     contents:
       - initial_split
       - initial_validation_split
-      - bootstraps
-      - vfold_cv
-      - loo_cv
-      - mc_cv
       - validation_set
+      - bootstraps
       - group_bootstraps
-      - group_mc_cv
+      - vfold_cv
       - group_vfold_cv
+      - mc_cv
+      - group_mc_cv
+      - clustering_cv
+      - nested_cv
+      - loo_cv
       - rolling_origin
       - sliding_window
-      - nested_cv
       - apparent
-      - manual_rset
       - permutations
-      - clustering_cv
+      - manual_rset
   - title: Analysis
     contents:
       - int_pctl


### PR DESCRIPTION
closes #392 

This now puts the grouped version of the `rset` functions closer to the corresponding ungrouped version. It does not combine the help pages for grouped and ungroup versions because sometimes, the text would get really long and not as easy to read.
