### PR TITLE
Paste the outputs of deparse() to guarantee a length-1 vector (Fixes #459)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # rsample (development version)
 
+* `nested_cv()` no longer errors if `outside` is a long call (#459, #461).
+
 # rsample 1.2.0
 
 * The new `initial_validation_split()`, along with variants `initial_validation_time_split()` and `group_initial_validation_split()`, generates a three-way split of the data into training, validation, and test sets. With the new `validation_set()`, this can be turned into an `rset` object for tuning (#403, #446).

--- a/R/nest.R
+++ b/R/nest.R
@@ -60,7 +60,14 @@ nested_cv <- function(data, outside, inside) {
 
   outer_cl <- cl[["outside"]]
   if (is_call(outer_cl)) {
-    if (grepl("^bootstraps", deparse(outer_cl))) {
+    using_bootstraps <- grepl(
+      "^bootstraps",
+      paste(
+        deparse(outer_cl, width.cutoff = 500L),
+        collapse = " "
+      )
+    )
+    if (using_bootstraps) {
       warn(boot_msg)
     }
     outer_cl <- rlang::call_modify(outer_cl, data = data)

--- a/tests/testthat/test-nesting.R
+++ b/tests/testthat/test-nesting.R
@@ -100,12 +100,11 @@ test_that("long calls don't error", {
       outside = sliding_period(
         index = date,
         period = "month",
-        origin = modeldata::Chicago$date[1])
-      ,
+        origin = modeldata::Chicago$date[1]
+      ),
       inside = vfold_cv(v = 4)
     )
   )
-
 })
 
 # ------------------------------------------------------------------------------

--- a/tests/testthat/test-nesting.R
+++ b/tests/testthat/test-nesting.R
@@ -92,6 +92,22 @@ test_that("rsplit labels", {
   expect_equal(all_labs, original_id)
 })
 
+test_that("long calls don't error", {
+  skip_if_not_installed("modeldata")
+  expect_no_error(
+    nested_cv(
+      modeldata::Chicago,
+      outside = sliding_period(
+        index = date,
+        period = "month",
+        origin = modeldata::Chicago$date[1])
+      ,
+      inside = vfold_cv(v = 4)
+    )
+  )
+
+})
+
 # ------------------------------------------------------------------------------
 # `[`
 skip_if_not_installed("withr")


### PR DESCRIPTION
This PR fixes #459 by ensuring `deparse()` generates a length-1 vector. The code to build `using_bootstraps` is taken from `deparse1()`, which was added in R 4.0; once rsample drops support for 3.6 it might make sense to change this to `deparse1()` instead for readability. The new test is taken directly from #459 's excellent reprex.

