### PR TITLE
Update vfold.R

### DIFF
--- a/R/vfold.R
+++ b/R/vfold.R
@@ -86,7 +86,7 @@ vfold_cv <- function(data, v = 10, repeats = 1,
       )
     }
     for (i in 1:repeats) {
-      tmp <- vfold_splits(data = data, v = v, strata = strata, pool = pool)
+      tmp <- vfold_splits(data = data, v = v, strata = strata, breaks = breaks ,pool = pool)
       tmp$id2 <- tmp$id
       tmp$id <- names0(repeats, "Repeat")[i]
       split_objs <- if (i == 1) {


### PR DESCRIPTION
Hello, 
this pull request is for bug correction with vfold_splits function
actually the vfold_splits function do not forward the breaks argument to vfold_splits call

Symptoms 
the de fault breaks = 4 is used instead

``` r
library(tidymodels)
set.seed(123)
d=iris[1:50,]
folds=vfold_cv(d, v = 5, repeats = 2,strata = Petal.Width)
#> Warning: The number of observations in each quantile is below the recommended threshold of 20.
#> • Stratification will use 2 breaks instead.
#> The number of observations in each quantile is below the recommended threshold of 20.
#> • Stratification will use 2 breaks instead.
folds=vfold_cv(d, v = 5, repeats = 2,strata = Petal.Width,
               breaks = 2)
#> Warning: The number of observations in each quantile is below the recommended threshold of 20.
#> • Stratification will use 2 breaks instead.
#> The number of observations in each quantile is below the recommended threshold of 20.
#> • Stratification will use 2 breaks instead.
```
obviously not forwarding the breaks argument 

no error after vfold_splits call modification 


<sup>Created on 2024-04-12 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>
