### PR TITLE
Fix class inheritance for apparent split objects

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@
 
 * `vfold_cv()` now utilizes the `breaks` argument correctly for repeated cross-validation (@ZWael, #471).
 
-* The `rsplit` objects of an `apparent()` split now have the correct class inheritance structure. The order is now `apparent_split` and then `rsplit` rather than the other way around.
+* The `rsplit` objects of an `apparent()` split now have the correct class inheritance structure. The order is now `apparent_split` and then `rsplit` rather than the other way around (#477).
 
 
 # rsample 1.2.1

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `vfold_cv()` now utilizes the `breaks` argument correctly for repeated cross-validation (@ZWael, #471).
 
+* The `rsplit` objects of an `apparent()` split now have the correct class inheritance structure. The order is now `apparent_split` and then `rsplit` rather than the other way around.
+
 
 # rsample 1.2.1
 

--- a/R/apparent.R
+++ b/R/apparent.R
@@ -18,9 +18,10 @@
 #' @export
 apparent <- function(data, ...) {
   check_dots_empty()
+
   splits <- rsplit(data, in_id = seq_len(nrow(data)), out_id = seq_len(nrow(data)))
-  # splits <- rm_out(splits)
-  class(splits) <- c("rsplit", "apparent_split")
+
+  class(splits) <- c("apparent_split", "rsplit")
   split_objs <- tibble::tibble(splits = list(splits), id = "Apparent")
 
   new_rset(

--- a/revdep/README.md
+++ b/revdep/README.md
@@ -1,8 +1,9 @@
 # Revdeps
 
-## Failed to check (1)
+## Failed to check (2)
 
 |package |version |error |warning |note |
 |:-------|:-------|:-----|:-------|:----|
-|NA      |?       |      |        |     |
+|psfmi   |1.4.0   |1     |        |     |
+|tidyfit |?       |      |        |     |
 

--- a/revdep/cran.md
+++ b/revdep/cran.md
@@ -1,7 +1,13 @@
 ## revdepcheck results
 
-We checked 44 reverse dependencies (43 from CRAN + 1 from Bioconductor), comparing R CMD check results across CRAN and dev versions of this package.
+We checked 51 reverse dependencies, comparing R CMD check results across CRAN and dev versions of this package.
 
  * We saw 0 new problems
- * We failed to check 0 packages
+ * We failed to check 2 packages
 
+Issues with CRAN packages are summarised below.
+
+### Failed to check
+
+* psfmi   (NA)
+* tidyfit (NA)

--- a/revdep/failures.md
+++ b/revdep/failures.md
@@ -1,13 +1,78 @@
-# NA
+# psfmi
 
 <details>
 
-* Version: NA
-* GitHub: NA
-* Source code: https://github.com/cran/NA
-* Number of recursive dependencies: 0
+* Version: 1.4.0
+* GitHub: https://github.com/mwheymans/psfmi
+* Source code: https://github.com/cran/psfmi
+* Date/Publication: 2023-06-17 22:40:02 UTC
+* Number of recursive dependencies: 159
 
-Run `cloud_details(, "NA")` for more info
+Run `cloud_details(, "psfmi")` for more info
+
+</details>
+
+## In both
+
+*   checking whether package ‘psfmi’ can be installed ... ERROR
+    ```
+    Installation failed.
+    See ‘/tmp/workdir/psfmi/new/psfmi.Rcheck/00install.out’ for details.
+    ```
+
+## Installation
+
+### Devel
+
+```
+* installing *source* package ‘psfmi’ ...
+** package ‘psfmi’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  namespace ‘Matrix’ 1.3-4 is already loaded, but >= 1.6.0 is required
+Calls: <Anonymous> ... namespaceImportFrom -> asNamespace -> loadNamespace
+Execution halted
+ERROR: lazy loading failed for package ‘psfmi’
+* removing ‘/tmp/workdir/psfmi/new/psfmi.Rcheck/psfmi’
+
+
+```
+### CRAN
+
+```
+* installing *source* package ‘psfmi’ ...
+** package ‘psfmi’ successfully unpacked and MD5 sums checked
+** using staged installation
+** R
+** data
+*** moving datasets to lazyload DB
+** inst
+** byte-compile and prepare package for lazy loading
+Error in loadNamespace(j <- i[[1L]], c(lib.loc, .libPaths()), versionCheck = vI[[j]]) : 
+  namespace ‘Matrix’ 1.3-4 is already loaded, but >= 1.6.0 is required
+Calls: <Anonymous> ... namespaceImportFrom -> asNamespace -> loadNamespace
+Execution halted
+ERROR: lazy loading failed for package ‘psfmi’
+* removing ‘/tmp/workdir/psfmi/old/psfmi.Rcheck/psfmi’
+
+
+```
+# tidyfit
+
+<details>
+
+* Version: 0.7.1
+* GitHub: https://github.com/jpfitzinger/tidyfit
+* Source code: https://github.com/cran/tidyfit
+* Date/Publication: 2024-03-23 15:20:02 UTC
+* Number of recursive dependencies: 186
+
+Run `cloud_details(, "tidyfit")` for more info
 
 </details>
 
@@ -16,7 +81,27 @@ Run `cloud_details(, "NA")` for more info
 ### Devel
 
 ```
-
+* using log directory ‘/tmp/workdir/tidyfit/new/tidyfit.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidyfit/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘tidyfit’ version ‘0.7.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+  ‘Flowchart.Rmd’ using ‘UTF-8’... OK
+  ‘Predicting_Boston_House_Prices.Rmd’ using ‘UTF-8’... OK
+  ‘Bootstrapping_Confidence_Intervals.Rmd’ using ‘UTF-8’... OK
+  ‘Feature_Selection.Rmd’ using ‘UTF-8’... failed
+  ‘Multinomial_Classification.Rmd’ using ‘UTF-8’... OK
+  ‘Rolling_Window_Time_Series_Regression.Rmd’ using ‘UTF-8’... OK
+  ‘Time-varying_parameters_vs_rolling_windows.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 ERRORs, 1 NOTE
 
 
 
@@ -26,7 +111,27 @@ Run `cloud_details(, "NA")` for more info
 ### CRAN
 
 ```
-
+* using log directory ‘/tmp/workdir/tidyfit/old/tidyfit.Rcheck’
+* using R version 4.1.1 (2021-08-10)
+* using platform: x86_64-pc-linux-gnu (64-bit)
+* using session charset: UTF-8
+* using option ‘--no-manual’
+* checking for file ‘tidyfit/DESCRIPTION’ ... OK
+* checking extension type ... Package
+* this is package ‘tidyfit’ version ‘0.7.1’
+* package encoding: UTF-8
+* checking package namespace information ... OK
+...
+  ‘Flowchart.Rmd’ using ‘UTF-8’... OK
+  ‘Predicting_Boston_House_Prices.Rmd’ using ‘UTF-8’... OK
+  ‘Bootstrapping_Confidence_Intervals.Rmd’ using ‘UTF-8’... OK
+  ‘Feature_Selection.Rmd’ using ‘UTF-8’... failed
+  ‘Multinomial_Classification.Rmd’ using ‘UTF-8’... OK
+  ‘Rolling_Window_Time_Series_Regression.Rmd’ using ‘UTF-8’... OK
+  ‘Time-varying_parameters_vs_rolling_windows.Rmd’ using ‘UTF-8’... OK
+* checking re-building of vignette outputs ... OK
+* DONE
+Status: 3 ERRORs, 1 NOTE
 
 
 


### PR DESCRIPTION
closes #477 

New order from specific to general.

revdep check: ` "823cd24a-61a6-4fe9-b523-380808911599"` flags `psfmi` and `tidyfit` but from grepping on the code in the corresponding github repositories I think those are a false alarm, i.e. the failure to install has nothing to do with this change.