### PR TITLE
Align class name for grouped MC splits

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `vfold_cv()` now utilizes the `breaks` argument correctly for repeated cross-validation (@ZWael, #471).
 
+* The class of grouped MC splits is now `group_mc_split` instead of `grouped_mc_split`, aligning it with the other grouped splits (#478).
+
 
 # rsample 1.2.1
 

--- a/R/mc.R
+++ b/R/mc.R
@@ -239,7 +239,7 @@ group_mc_splits <- function(data, group, prop = 3 / 4, times = 25, strata = NULL
       indices,
       make_splits,
       data = data,
-      class = c("grouped_mc_split", "mc_split")
+      class = c("group_mc_split", "mc_split")
     )
 
   all_assessable <- purrr::map(split_objs, function(x) nrow(assessment(x)))

--- a/tests/testthat/test-initial.R
+++ b/tests/testthat/test-initial.R
@@ -45,7 +45,7 @@ test_that("default time param with lag", {
 
 test_that("default group param", {
   rs1 <- group_initial_split(dat1, c)
-  expect_equal(class(rs1), c("group_initial_split", "initial_split", "grouped_mc_split", "mc_split", "rsplit"))
+  expect_equal(class(rs1), c("group_initial_split", "initial_split", "group_mc_split", "mc_split", "rsplit"))
   tr1 <- training(rs1)
   ts1 <- testing(rs1)
   expect_equal(nrow(tr1), nrow(dat1) * 3 / 4)
@@ -103,7 +103,7 @@ test_that("grouping -- strata", {
 
 test_that("`prop` computes the proportion for group analysis", {
   rs1 <- group_initial_split(dat1, c, prop = 1 / 2)
-  expect_equal(class(rs1), c("group_initial_split", "initial_split", "grouped_mc_split", "mc_split", "rsplit"))
+  expect_equal(class(rs1), c("group_initial_split", "initial_split", "group_mc_split", "mc_split", "rsplit"))
   tr1 <- training(rs1)
   ts1 <- testing(rs1)
   expect_equal(nrow(tr1), nrow(dat1) * 1 / 2)


### PR DESCRIPTION
closes #478

revdepchecks: `"ce875419-a3ca-4960-9294-a2ed5165356d"` with the same results and conclusion as https://github.com/tidymodels/rsample/pull/481