### PR TITLE
Allow explicit specification of `strata = NULL` for grouped resampling

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * `vfold_cv()` now utilizes the `breaks` argument correctly for repeated cross-validation (@ZWael, #471).
 
+* Grouped resampling functions now work with an explicit `strata = NULL` instead of strata being either a name or missing (#485).
+
 ## Breaking changes
 
 * The class of grouped MC splits is now `group_mc_split` instead of `grouped_mc_split`, aligning it with the other grouped splits (#478).

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -345,6 +345,12 @@ check_v <- function(v, max_v, rows = "rows", call = rlang::caller_env()) {
 check_grouped_strata <- function(group, strata, pool, data) {
 
   strata <- tidyselect::vars_select(names(data), !!enquo(strata))
+
+  # if strata was NULL this is empty, thus return NULL
+  if (length(strata) < 1) {
+    return(NULL)
+  }
+
   grouped_table <- tibble(
     group = getElement(data, group),
     strata = getElement(data, strata)

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -143,6 +143,18 @@ test_that("grouping -- default param", {
   expect_true(all(table(sp_out) == 1))
 })
 
+test_that("grouping works with non-missing strata = NULL", {
+  set.seed(11)
+  rset_strata_missing <- group_vfold_cv(warpbreaks, "tension")
+
+  expect_no_error({
+    set.seed(11)
+    rset_strata_null <- group_vfold_cv(warpbreaks, "tension", strata = NULL)
+  })
+  
+  expect_identical(rset_strata_null, rset_strata_missing)
+
+})
 
 test_that("grouping -- v < max v", {
   set.seed(11)


### PR DESCRIPTION
closes  #485

``` r
library(rsample)

set.seed(11)
rs1 <- group_vfold_cv(warpbreaks, "tension")

rs1 <- group_vfold_cv(warpbreaks, "tension", strata = NULL)
```

<sup>Created on 2024-05-22 with [reprex v2.1.0](https://reprex.tidyverse.org)</sup>