### PR TITLE
`creat` -> `create` in `inner_split()` docs

### DIFF
--- a/R/inner_split.R
+++ b/R/inner_split.R
@@ -7,7 +7,7 @@
 #' @details
 #' `rsplit` objects live most commonly inside of an `rset` object. The 
 #' `split_args` argument can be the output of [.get_split_args()] on that 
-#' corresponding `rset` object, even if some of the arguments used to creat the 
+#' corresponding `rset` object, even if some of the arguments used to create the 
 #' `rset` object are not needed for the inner split. 
 #' * For `mc_split` and `group_mc_split` objects, `inner_split()` will ignore 
 #' `split_args$times`.

--- a/man/inner_split.Rd
+++ b/man/inner_split.Rd
@@ -46,7 +46,7 @@ Inner split of the analysis set for fitting a post-processor
 \details{
 \code{rsplit} objects live most commonly inside of an \code{rset} object. The
 \code{split_args} argument can be the output of \code{\link[=.get_split_args]{.get_split_args()}} on that
-corresponding \code{rset} object, even if some of the arguments used to creat the
+corresponding \code{rset} object, even if some of the arguments used to create the
 \code{rset} object are not needed for the inner split.
 \itemize{
 \item For \code{mc_split} and \code{group_mc_split} objects, \code{inner_split()} will ignore


### PR DESCRIPTION
Missed this in a previous PR review. :)