### PR TITLE
Fixes #475 - Documentation edits-decluttering the top of the refs page

### DIFF
--- a/R/initial_split.R
+++ b/R/initial_split.R
@@ -6,7 +6,9 @@
 #'  `group_initial_split` creates splits of the data based
 #'  on some grouping variable, so that all data in a "group" is assigned to
 #'  the same split.
-#'  `training` and `testing` are used to extract the resulting data.
+#'
+#' @details `training` and `testing` are used to extract the resulting data.
+#'
 #' @template strata_details
 #' @inheritParams vfold_cv
 #' @inheritParams make_strata
@@ -176,12 +178,12 @@ group_initial_split <- function(data, group, prop = 3 / 4, ..., strata = NULL, p
   attrib <- .get_split_args(res, allow_strata_false = TRUE)
 
   res <- res$splits[[1]]
-  
+
   attrib$times <- NULL
   for (i in names(attrib)) {
     attr(res, i) <- attrib[[i]]
   }
   class(res) <- c("group_initial_split", "initial_split", class(res))
-  
+
   res
 }

--- a/R/initial_validation_split.R
+++ b/R/initial_validation_split.R
@@ -8,7 +8,8 @@
 #' `group_initial_validation_split()` creates similar random splits of the data
 #' based on some grouping variable, so that all data in a "group" are assigned
 #' to the same partition.
-#' `training()`, `validation()`, and `testing()` can be used to extract the
+#'
+#' @details `training()`, `validation()`, and `testing()` can be used to extract the
 #' resulting data sets.
 #' Use [`validation_set()`] to create an `rset` object for use with functions from
 #' the tune package such as `tune::tune_grid()`.

--- a/R/validation_set.R
+++ b/R/validation_set.R
@@ -1,5 +1,7 @@
 #' Create a Validation Split for Tuning
 #'
+#' `validation_set` creates a the validation split for model tuning.
+#'
 #' @param split An object of class `initial_validation_split`, such as resulting
 #' from [initial_validation_split()] or [group_initial_validation_split()].
 #' @param x An `rsplit` object produced by `validation_set()`.

--- a/man/initial_split.Rd
+++ b/man/initial_split.Rd
@@ -71,9 +71,10 @@ set and testing set. \code{initial_time_split} does the same, but takes the
 \code{group_initial_split} creates splits of the data based
 on some grouping variable, so that all data in a "group" is assigned to
 the same split.
-\code{training} and \code{testing} are used to extract the resulting data.
 }
 \details{
+\code{training} and \code{testing} are used to extract the resulting data.
+
 With a \code{strata} argument, the random sampling is conducted
 \emph{within the stratification variable}. This can help ensure that the
 resamples have equivalent proportions as the original data set. For

--- a/man/initial_validation_split.Rd
+++ b/man/initial_validation_split.Rd
@@ -81,12 +81,13 @@ data set, with the first observations being put into the training set.
 \code{group_initial_validation_split()} creates similar random splits of the data
 based on some grouping variable, so that all data in a "group" are assigned
 to the same partition.
+}
+\details{
 \code{training()}, \code{validation()}, and \code{testing()} can be used to extract the
 resulting data sets.
 Use \code{\link[=validation_set]{validation_set()}} to create an \code{rset} object for use with functions from
 the tune package such as \code{tune::tune_grid()}.
-}
-\details{
+
 With a \code{strata} argument, the random sampling is conducted
 \emph{within the stratification variable}. This can help ensure that the
 resamples have equivalent proportions as the original data set. For

--- a/man/validation_set.Rd
+++ b/man/validation_set.Rd
@@ -35,7 +35,7 @@ An tibble with classes \code{validation_set}, \code{rset}, \code{tbl_df}, \code{
 column called \code{id} that has a character string with the resample identifier.
 }
 \description{
-Create a Validation Split for Tuning
+\code{validation_set} creates a the validation split for model tuning.
 }
 \examples{
 set.seed(1353)


### PR DESCRIPTION
Fixes #475 - moved args into details section for first three functions to keep references page doc decluttered 