### PR TITLE
Fixed #464 improved spacing in pretty methods.

### DIFF
--- a/R/printing.R
+++ b/R/printing.R
@@ -55,10 +55,10 @@ pretty.mc_cv <- function(x, ...) {
     signif(1 - details$prop, 2),
     ") with ",
     details$times,
-    " resamples "
+    " resamples"
   )
   if (has_strata(details)) {
-    res <- paste(res, "using stratification")
+    res <- paste(res, " using stratification")
   }
   res
 }

--- a/tests/testthat/_snaps/mc.md
+++ b/tests/testthat/_snaps/mc.md
@@ -3,7 +3,7 @@
     Code
       mc_cv(warpbreaks)
     Output
-      # Monte Carlo cross-validation (0.75/0.25) with 25 resamples  
+      # Monte Carlo cross-validation (0.75/0.25) with 25 resamples 
       # A tibble: 25 x 2
          splits          id        
          <list>          <chr>     


### PR DESCRIPTION
Fixed #464. As Emil suggested, I improved the spaces when printing, therefore, I removed trailing space from line 58 and added a leading space in line 61. 