### PR TITLE
Prevent LOO through vfold_cv()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * Started moving error messages to cli (#499, #502).
 
+* `vfold_cv()` and `clustering_cv()` now error on implicit leave-one-out cross-validation (@seb09, #527).
+
 ## Bug fixes
 
 * `vfold_cv()` now utilizes the `breaks` argument correctly for repeated cross-validation (@ZWael, #471).

--- a/R/loo.R
+++ b/R/loo.R
@@ -13,7 +13,7 @@
 #' @export
 loo_cv <- function(data, ...) {
   check_dots_empty()
-  split_objs <- vfold_splits(data = data, v = nrow(data))
+  split_objs <- vfold_splits(data = data, v = nrow(data), prevent_loo = FALSE)
   split_objs <-
     list(
       splits = map(split_objs$splits, change_class),

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -124,10 +124,10 @@ vfold_cv <- function(data, v = 10, repeats = 1,
 }
 
 
-vfold_splits <- function(data, v = 10, strata = NULL, breaks = 4, pool = 0.1) {
+vfold_splits <- function(data, v = 10, strata = NULL, breaks = 4, pool = 0.1, prevent_loo = TRUE) {
 
   n <- nrow(data)
-  check_v(v, n, call = rlang::caller_env())
+  check_v(v, n, prevent_loo = prevent_loo, call = rlang::caller_env())
 
   if (is.null(strata)) {
     folds <- sample(rep(1:v, length.out = n))

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -12,9 +12,7 @@
 #' @template strata_details
 #' @inheritParams make_strata
 #' @param data A data frame.
-#' @param v The number of partitions of the data set. Should be an integer
-#' smaller than `nrow(data)`. If you want to create a split for a leave-one-out
-#' cross-validation (`v = nrow(data)`), please use [loo_cv()] instead.
+#' @param v The number of partitions of the data set.
 #' @param repeats The number of times to repeat the V-fold partitioning.
 #' @param strata A variable in `data` (single character or name) used to conduct
 #'  stratified sampling. When not `NULL`, each resample is created within the

--- a/R/vfold.R
+++ b/R/vfold.R
@@ -313,7 +313,7 @@ group_vfold_splits <- function(data, group, v = NULL, balance, strata = NULL, po
   if (is.null(v)) {
     v <- max_v
   }
-  check_v(v = v, max_v = max_v, rows = "groups", call = rlang::caller_env())
+  check_v(v = v, max_v = max_v, rows = "groups", prevent_loo = FALSE, call = rlang::caller_env())
 
   indices <- make_groups(data, group, v, balance, strata)
   indices <- lapply(indices, default_complement, n = nrow(data))

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -9,7 +9,9 @@ vfold_cv(data, v = 10, repeats = 1, strata = NULL, breaks = 4, pool = 0.1, ...)
 \arguments{
 \item{data}{A data frame.}
 
-\item{v}{The number of partitions of the data set.}
+\item{v}{The number of partitions of the data set. Should be an integer
+smaller than \code{nrow(data)}. If you want to create a split for a leave-one-out
+cross-validation (\code{v = nrow(data)}), please use \code{\link[=loo_cv]{loo_cv()}} instead.}
 
 \item{repeats}{The number of times to repeat the V-fold partitioning.}
 

--- a/man/vfold_cv.Rd
+++ b/man/vfold_cv.Rd
@@ -9,9 +9,7 @@ vfold_cv(data, v = 10, repeats = 1, strata = NULL, breaks = 4, pool = 0.1, ...)
 \arguments{
 \item{data}{A data frame.}
 
-\item{v}{The number of partitions of the data set. Should be an integer
-smaller than \code{nrow(data)}. If you want to create a split for a leave-one-out
-cross-validation (\code{v = nrow(data)}), please use \code{\link[=loo_cv]{loo_cv()}} instead.}
+\item{v}{The number of partitions of the data set.}
 
 \item{repeats}{The number of times to repeat the V-fold partitioning.}
 

--- a/tests/testthat/_snaps/clustering.md
+++ b/tests/testthat/_snaps/clustering.md
@@ -30,6 +30,16 @@
 
     `repeats` must be a single positive integer
 
+---
+
+    Code
+      clustering_cv(mtcars, mpg, v = nrow(mtcars))
+    Condition
+      Error in `clustering_cv()`:
+      ! Leave-one-out cross-validation is not supported by this function.
+      x You set `v` to `nrow(data)`, which would result in a leave-one-out cross-validation.
+      i Use `loo_cv()` in this case.
+
 # printing
 
     Code

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -25,7 +25,9 @@
 
 ---
 
-    Repeated resampling when `v` is 150 would create identical resamples
+    Leave-one-out cross-validation is not supported by `vfold_cv()`.
+    x You set `v` to `nrow(data)`, which would result in a leave-one-out cross-validation.
+    i Use `loo_cv()` in this case.
 
 ---
 

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -25,9 +25,7 @@
 
 ---
 
-    Leave-one-out cross-validation is not supported by `vfold_cv()`.
-    x You set `v` to `nrow(data)`, which would result in a leave-one-out cross-validation.
-    i Use `loo_cv()` in this case.
+    Repeated resampling when `v` is 150 would create identical resamples
 
 ---
 

--- a/tests/testthat/_snaps/vfold.md
+++ b/tests/testthat/_snaps/vfold.md
@@ -35,6 +35,16 @@
 
     `repeats` must be a single positive integer
 
+---
+
+    Code
+      vfold_cv(mtcars, v = nrow(mtcars))
+    Condition
+      Error in `vfold_cv()`:
+      ! Leave-one-out cross-validation is not supported by this function.
+      x You set `v` to `nrow(data)`, which would result in a leave-one-out cross-validation.
+      i Use `loo_cv()` in this case.
+
 # printing
 
     Code

--- a/tests/testthat/test-clustering.R
+++ b/tests/testthat/test-clustering.R
@@ -45,6 +45,7 @@ test_that("bad args", {
   expect_snapshot(error = TRUE, clustering_cv(Orange, v = 1, vars = "Tree"))
   expect_snapshot_error(clustering_cv(Orange, repeats = 0))
   expect_snapshot_error(clustering_cv(Orange, repeats = NULL))
+  expect_snapshot(error = TRUE, clustering_cv(mtcars, mpg, v = nrow(mtcars)))
 })
 
 test_that("printing", {

--- a/tests/testthat/test-vfold.R
+++ b/tests/testthat/test-vfold.R
@@ -85,6 +85,7 @@ test_that("bad args", {
   expect_snapshot_error(vfold_cv(iris, v = 150, repeats = 2))
   expect_snapshot_error(vfold_cv(Orange, repeats = 0))
   expect_snapshot_error(vfold_cv(Orange, repeats = NULL))
+  expect_snapshot(error = TRUE, vfold_cv(mtcars, v = nrow(mtcars)))
 })
 
 test_that("printing", {


### PR DESCRIPTION
vfold_cv() throws an error, if used for leave-one-out cross-validation, refering to loo_cv() instead. Fixes #440