### PR TITLE
Upkeep for `int_*()` functions

### DIFF
--- a/R/bootci.R
+++ b/R/bootci.R
@@ -178,8 +178,8 @@ pctl_single <- function(stats, alpha = 0.05) {
 #' Bootstrap confidence intervals
 #' @description
 #' Calculate bootstrap confidence intervals using various methods.
-#' @param .data A data frame containing the bootstrap resamples created using
-#'  `bootstraps()`. For t- and BCa-intervals, the `apparent` argument
+#' @param .data A object containing the bootstrap resamples, created using
+#'  [bootstraps()]. For t- and BCa-intervals, the `apparent` argument
 #'  should be set to `TRUE`. Even if the `apparent` argument is set to
 #'  `TRUE` for the percentile method, the apparent data is never used in calculating
 #'  the percentile confidence interval.

--- a/man/int_pctl.Rd
+++ b/man/int_pctl.Rd
@@ -22,8 +22,8 @@ int_bca(.data, ...)
 \method{int_bca}{bootstraps}(.data, statistics, alpha = 0.05, .fn, ...)
 }
 \arguments{
-\item{.data}{A data frame containing the bootstrap resamples created using
-\code{bootstraps()}. For t- and BCa-intervals, the \code{apparent} argument
+\item{.data}{A object containing the bootstrap resamples, created using
+\code{\link[=bootstraps]{bootstraps()}}. For t- and BCa-intervals, the \code{apparent} argument
 should be set to \code{TRUE}. Even if the \code{apparent} argument is set to
 \code{TRUE} for the percentile method, the apparent data is never used in calculating
 the percentile confidence interval.}

--- a/tests/testthat/_snaps/bootci.md
+++ b/tests/testthat/_snaps/bootci.md
@@ -161,22 +161,6 @@
 ---
 
     Code
-      int_t(bt_norm %>% dplyr::filter(id != "Apparent"), stats)
-    Condition
-      Error in `UseMethod()`:
-      ! no applicable method for 'int_t' applied to an object of class "c('tbl_df', 'tbl', 'data.frame')"
-
----
-
-    Code
-      int_bca(bt_norm %>% dplyr::filter(id != "Apparent"), stats, .fn = get_stats)
-    Condition
-      Error in `UseMethod()`:
-      ! no applicable method for 'int_bca' applied to an object of class "c('tbl_df', 'tbl', 'data.frame')"
-
----
-
-    Code
       int_pctl(badder_bt_norm, bad_term)
     Condition
       Error in `int_pctl()`:

--- a/tests/testthat/test-bootci.R
+++ b/tests/testthat/test-bootci.R
@@ -199,7 +199,7 @@ test_that("bad input", {
     dplyr::mutate(
       stats = purrr::map(splits, ~ get_stats(.x)),
       junk = 1:11
-   )
+    )
 
   expect_snapshot(error = TRUE, {
     int_pctl(bt_small, id)
@@ -262,15 +262,9 @@ test_that("bad input", {
   expect_snapshot(error = TRUE, {
     int_t(as.data.frame(bt_norm), stats)
   })
-  expect_snapshot(error = TRUE, {
-    int_bca(as.data.frame(bt_norm), stats, .fn = get_stats)
-  })
 
   expect_snapshot(error = TRUE, {
-    int_t(bt_norm %>% dplyr::filter(id != "Apparent"), stats)
-  })
-  expect_snapshot(error = TRUE, {
-    int_bca(bt_norm %>% dplyr::filter(id != "Apparent"), stats, .fn = get_stats)
+    int_bca(as.data.frame(bt_norm), stats, .fn = get_stats)
   })
 
   poo <- function(x) {
@@ -280,9 +274,15 @@ test_that("bad input", {
   badder_bt_norm <-
     bt_norm %>%
     mutate(
-      bad_term = purrr::map(stats, ~ .x %>% setNames(c("a", "estimate", "std.err"))),
+      bad_term = purrr::map(
+        stats,
+        ~ .x %>% setNames(c("a", "estimate", "std.err"))
+      ),
       bad_est = purrr::map(stats, ~ .x %>% setNames(c("term", "b", "std.err"))),
-      bad_err = purrr::map(stats, ~ .x %>% setNames(c("term", "estimate", "c"))),
+      bad_err = purrr::map(
+        stats,
+        ~ .x %>% setNames(c("term", "estimate", "c"))
+      ),
       bad_num = purrr::map(stats, ~ poo(.x))
     )
   expect_snapshot(error = TRUE, {


### PR DESCRIPTION
closes #545

Removing the tests on "is the apparent bootstrap sample available?" as there is a separate test for that already right below.

Leaving the tests which drop into the default method (from `data.frame`s) for #544.