### PR TITLE
Polish classes of `inner_split` objects

### DIFF
--- a/R/inner_split.R
+++ b/R/inner_split.R
@@ -55,7 +55,7 @@ inner_split.mc_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = mc_splits,
     split_args = split_args,
-    classes = c("mc_split_inner", class(x))
+    classes = c("mc_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -74,7 +74,7 @@ inner_split.group_mc_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = group_mc_splits,
     split_args = split_args,
-    classes = c("group_mc_split_inner", class(x))
+    classes = c("group_mc_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -104,7 +104,7 @@ inner_split.vfold_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = mc_splits,
     split_args = split_args,
-    classes = c("vfold_split_inner", class(x))
+    classes = c("vfold_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -133,7 +133,7 @@ inner_split.group_vfold_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = group_mc_splits,
     split_args = split_args,
-    classes = c("group_vfold_split_inner", class(x))
+    classes = c("group_vfold_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -180,7 +180,7 @@ inner_split.boot_split <- function(x, split_args, ...) {
   }
 
   class_inner <- "boot_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -222,7 +222,7 @@ inner_split.group_boot_split <- function(x, split_args, ...) {
   }
 
   class_inner <- "group_boot_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -249,7 +249,7 @@ inner_split.val_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = mc_splits,
     split_args = split_args,
-    classes = c("val_split_inner", class(x))
+    classes = c("val_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -275,7 +275,7 @@ inner_split.group_val_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = group_mc_splits,
     split_args = split_args,
-    classes = c("group_val_split_inner", class(x))
+    classes = c("group_val_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -300,7 +300,7 @@ inner_split.time_val_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = initial_time_split,
     split_args = split_args,
-    classes = c("time_val_split_inner", class(x))
+    classes = c("time_val_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -323,7 +323,7 @@ inner_split.clustering_split <- function(x, split_args, ...) {
     analysis_set,
     split_function = clustering_cv,
     split_args = split_args,
-    classes = c("clustering_split_inner", class(x))
+    classes = c("clustering_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -343,7 +343,7 @@ inner_split.apparent_split <- function(x, ...) {
   split_inner <- split_inner$splits[[1]]
 
   class_inner <- "apparent_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -364,7 +364,11 @@ inner_split.sliding_window_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = c("sliding_window_split_inner", "sliding_window_split")
+      class = c(
+        "sliding_window_split_inner",
+        "inner_split",
+        "sliding_window_split"
+      )
     )
     return(split_inner)
   }
@@ -418,7 +422,7 @@ inner_split.sliding_window_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_window_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -436,7 +440,11 @@ inner_split.sliding_index_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = c("sliding_index_split_inner", "sliding_index_split")
+      class = c(
+        "sliding_index_split_inner",
+        "inner_split",
+        "sliding_index_split"
+      )
     )
     return(split_inner)
   }
@@ -493,7 +501,7 @@ inner_split.sliding_index_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_index_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -511,7 +519,11 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = c("sliding_period_split_inner", "sliding_period_split")
+      class = c(
+        "sliding_period_split_inner",
+        "inner_split",
+        "sliding_period_split"
+      )
     )
     return(split_inner)
   }
@@ -521,7 +533,11 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = c("sliding_period_split_inner", "sliding_period_split")
+      class = c(
+        "sliding_period_split_inner",
+        "inner_split",
+        "sliding_period_split"
+      )
     )
     return(split_inner)
   }
@@ -584,7 +600,7 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_period_split_inner"
-  class(split_inner) <- c(class_inner, class(x))
+  class(split_inner) <- c(class_inner, "inner_split", class(x))
   split_inner
 }
 
@@ -640,7 +656,7 @@ inner_split.initial_time_split <- function(x, split_args, ...) {
     training_set,
     split_function = initial_time_split,
     split_args = split_args,
-    classes = c("initial_time_split_inner", class(x))
+    classes = c("initial_time_split_inner", "inner_split", class(x))
   )
 
   split_inner
@@ -663,7 +679,12 @@ inner_split.initial_validation_split <- function(x, split_args, ...) {
     training_set,
     split_function = mc_splits,
     split_args = split_args,
-    classes = c("initial_validation_split_inner", "mc_split", "rsplit")
+    classes = c(
+      "initial_validation_split_inner",
+      "inner_split",
+      "mc_split",
+      "rsplit"
+    )
   )
 
   split_inner
@@ -685,6 +706,7 @@ inner_split.group_initial_validation_split <- function(x, split_args, ...) {
     split_args = split_args,
     classes = c(
       "group_initial_validation_split_inner",
+      "inner_split",
       "group_mc_split",
       "mc_split",
       "rsplit"
@@ -708,7 +730,7 @@ inner_split.initial_validation_time_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(training_set)
     class_inner <- "initial_validation_time_split_inner"
-    class(split_inner) <- c(class_inner, class(split_inner))
+    class(split_inner) <- c(class_inner, "inner_split", class(split_inner))
     return(split_inner)
   }
 
@@ -724,7 +746,7 @@ inner_split.initial_validation_time_split <- function(x, split_args, ...) {
   )
 
   class_inner <- "initial_validation_time_split_inner"
-  class(split_inner) <- c(class_inner, class(split_inner))
+  class(split_inner) <- c(class_inner, "inner_split", class(split_inner))
   split_inner
 }
 

--- a/R/inner_split.R
+++ b/R/inner_split.R
@@ -418,7 +418,7 @@ inner_split.sliding_window_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_window_split_inner"
-  split_inner <- add_class(split_inner, class_inner)
+  class(split_inner) <- c(class_inner, class(x))
   split_inner
 }
 
@@ -493,7 +493,7 @@ inner_split.sliding_index_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_index_split_inner"
-  split_inner <- add_class(split_inner, class_inner)
+  class(split_inner) <- c(class_inner, class(x))
   split_inner
 }
 
@@ -584,7 +584,7 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
   # no need to use skip and step args since they don't apply to _within_ an rsplit
 
   class_inner <- "sliding_period_split_inner"
-  split_inner <- add_class(split_inner, class_inner)
+  class(split_inner) <- c(class_inner, class(x))
   split_inner
 }
 

--- a/R/inner_split.R
+++ b/R/inner_split.R
@@ -364,7 +364,7 @@ inner_split.sliding_window_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = "sliding_window_split_inner"
+      class = c("sliding_window_split_inner", "sliding_window_split")
     )
     return(split_inner)
   }
@@ -436,7 +436,7 @@ inner_split.sliding_index_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = "sliding_index_split_inner"
+      class = c("sliding_index_split_inner", "sliding_index_split")
     )
     return(split_inner)
   }
@@ -511,7 +511,7 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = "sliding_period_split_inner"
+      class = c("sliding_period_split_inner", "sliding_period_split")
     )
     return(split_inner)
   }
@@ -521,7 +521,7 @@ inner_split.sliding_period_split <- function(x, split_args, ...) {
     )
     split_inner <- internal_calibration_split_mock(
       analysis_set,
-      class = "sliding_period_split_inner"
+      class = c("sliding_period_split_inner", "sliding_period_split")
     )
     return(split_inner)
   }
@@ -663,7 +663,7 @@ inner_split.initial_validation_split <- function(x, split_args, ...) {
     training_set,
     split_function = mc_splits,
     split_args = split_args,
-    classes = c("initial_validation_split_inner", "mcsplit", "rsplit")
+    classes = c("initial_validation_split_inner", "mc_split", "rsplit")
   )
 
   split_inner

--- a/tests/testthat/test-inner_split.R
+++ b/tests/testthat/test-inner_split.R
@@ -608,6 +608,12 @@ test_that("sliding_window_split", {
     isplit$data[isplit$out_id, , drop = FALSE],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_window_split_inner", "sliding_window_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("sliding_window_split needs at least 2 observations", {
@@ -721,6 +727,12 @@ test_that("sliding_index_split", {
     assessment(isplit),
     isplit$data[isplit$out_id, , drop = FALSE],
     ignore_attr = "row.names"
+  )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_index_split_inner", "sliding_index_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -881,6 +893,12 @@ test_that("sliding_period_split", {
     assessment(i_split),
     i_split$data[i_split$out_id, , drop = FALSE],
     ignore_attr = "row.names"
+  )
+
+  expect_s3_class(
+    i_split,
+    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    exact = TRUE
   )
 })
 

--- a/tests/testthat/test-inner_split.R
+++ b/tests/testthat/test-inner_split.R
@@ -43,6 +43,12 @@ test_that("mc_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("mc_split_inner", "mc_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("mc_split can create mock split", {
@@ -66,6 +72,12 @@ test_that("mc_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("mc_split_inner", "mc_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -96,6 +108,12 @@ test_that("group_mc_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("group_mc_split_inner", "group_mc_split", "mc_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("group_mc_split can create mock split", {
@@ -118,6 +136,12 @@ test_that("group_mc_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("group_mc_split_inner", "group_mc_split", "mc_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -147,6 +171,12 @@ test_that("vfold_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("vfold_split_inner", "vfold_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("vfold_split can create mock split", {
@@ -169,6 +199,12 @@ test_that("vfold_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("vfold_split_inner", "vfold_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -199,6 +235,12 @@ test_that("group_vfold_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("group_vfold_split_inner", "group_vfold_split", "vfold_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("group_vfold_split can create mock split", {
@@ -221,6 +263,12 @@ test_that("group_vfold_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("group_vfold_split_inner", "group_vfold_split", "vfold_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -249,6 +297,11 @@ test_that("boot_split", {
     isplit$data[complement(isplit), ],
     ignore_attr = "row.names"
   )
+  expect_s3_class(
+    isplit,
+    c("boot_split_inner", "boot_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("boot_split can create mock split", {
@@ -271,6 +324,12 @@ test_that("boot_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("boot_split_inner", "boot_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -301,6 +360,12 @@ test_that("group_boot_split", {
     isplit$data[complement(isplit), ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("group_boot_split_inner", "group_boot_split", "boot_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("group_boot_split can create mock split", {
@@ -323,6 +388,12 @@ test_that("group_boot_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("group_boot_split_inner", "group_boot_split", "boot_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -356,6 +427,12 @@ test_that("initial_validation_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("val_split_inner", "val_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("val_split can create mock split", {
@@ -379,6 +456,12 @@ test_that("val_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("val_split_inner", "val_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -414,6 +497,12 @@ test_that("group_initial_validation_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("group_val_split_inner", "group_val_split", "val_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("group_val_split can create mock split", {
@@ -441,6 +530,12 @@ test_that("group_val_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("group_val_split_inner", "group_val_split", "val_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -471,6 +566,12 @@ test_that("initial_validation_time_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("time_val_split_inner", "time_val_split", "val_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("time_val_split can create mock split", {
@@ -494,6 +595,12 @@ test_that("time_val_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("time_val_split_inner", "time_val_split", "val_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -523,6 +630,12 @@ test_that("clustering_split", {
     isplit$data[-isplit$in_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("clustering_split_inner", "clustering_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("clustering_split can create mock split", {
@@ -545,6 +658,12 @@ test_that("clustering_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("clustering_split_inner", "clustering_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -569,6 +688,12 @@ test_that("apparent_split", {
   expect_identical(
     assessment(isplit),
     analysis(r_split)
+  )
+
+  expect_s3_class(
+    isplit,
+    c("apparent_split_inner", "apparent_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -635,6 +760,12 @@ test_that("sliding_window_split needs at least 2 observations", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_window_split_inner", "sliding_window_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -800,6 +931,12 @@ test_that("sliding_index_split needs at least 2 observations", {
     nrow(assessment(isplit)),
     0L
   )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_index_split_inner", "sliding_index_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("sliding_index_split with incomplete sets", {
@@ -938,6 +1075,12 @@ test_that("sliding_period_split needs at least 2 observations", {
     nrow(assessment(isplit)),
     0L
   )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("sliding_period_split needs observations in at least 2 periods", {
@@ -962,6 +1105,12 @@ test_that("sliding_period_split needs observations in at least 2 periods", {
     0L
   )
 
+  expect_s3_class(
+    isplit,
+    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    exact = TRUE
+  )
+
   index <- vctrs::new_date(c(0, 1, 2, 32))
   df <- data.frame(index = index)
 
@@ -981,6 +1130,12 @@ test_that("sliding_period_split needs observations in at least 2 periods", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -1006,6 +1161,12 @@ test_that("initial_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("mc_split_inner", "initial_split", "mc_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("group_initial_split", {
@@ -1027,6 +1188,19 @@ test_that("group_initial_split", {
     assessment(isplit),
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
+  )
+
+  expect_s3_class(
+    isplit,
+    c(
+      "group_mc_split_inner",
+      "group_initial_split",
+      "initial_split",
+      "group_mc_split",
+      "mc_split",
+      "rsplit"
+    ),
+    exact = TRUE
   )
 })
 
@@ -1050,6 +1224,17 @@ test_that("initial_time_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c(
+      "initial_time_split_inner",
+      "initial_time_split",
+      "initial_split",
+      "rsplit"
+    ),
+    exact = TRUE
+  )
 })
 
 test_that("initial_time_split can create mock split", {
@@ -1070,6 +1255,17 @@ test_that("initial_time_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c(
+      "initial_time_split_inner",
+      "initial_time_split",
+      "initial_split",
+      "rsplit"
+    ),
+    exact = TRUE
   )
 })
 
@@ -1096,6 +1292,12 @@ test_that("initial_validation_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("initial_validation_split_inner", "mc_split", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("initial_validation_split can create mock split", {
@@ -1117,6 +1319,12 @@ test_that("initial_validation_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("initial_validation_split_inner", "mc_split", "rsplit"),
+    exact = TRUE
   )
 })
 
@@ -1142,6 +1350,17 @@ test_that("group_initial_validation_split", {
     assessment(isplit),
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
+  )
+
+  expect_s3_class(
+    isplit,
+    c(
+      "group_initial_validation_split_inner",
+      "group_mc_split",
+      "mc_split",
+      "rsplit"
+    ),
+    exact = TRUE
   )
 })
 
@@ -1169,6 +1388,17 @@ test_that("group_initial_validation_split can create mock split", {
     nrow(assessment(isplit)),
     0L
   )
+
+  expect_s3_class(
+    isplit,
+    c(
+      "group_initial_validation_split_inner",
+      "group_mc_split",
+      "mc_split",
+      "rsplit"
+    ),
+    exact = TRUE
+  )
 })
 
 test_that("initial_validation_time_split", {
@@ -1194,6 +1424,12 @@ test_that("initial_validation_time_split", {
     isplit$data[isplit$out_id, ],
     ignore_attr = "row.names"
   )
+
+  expect_s3_class(
+    isplit,
+    c("initial_validation_time_split_inner", "rsplit"),
+    exact = TRUE
+  )
 })
 
 test_that("initial_validation_time_split can create mock split", {
@@ -1215,6 +1451,12 @@ test_that("initial_validation_time_split can create mock split", {
   expect_identical(
     nrow(assessment(isplit)),
     0L
+  )
+
+  expect_s3_class(
+    isplit,
+    c("initial_validation_time_split_inner", "rsplit"),
+    exact = TRUE
   )
 })
 

--- a/tests/testthat/test-inner_split.R
+++ b/tests/testthat/test-inner_split.R
@@ -46,7 +46,7 @@ test_that("mc_split", {
 
   expect_s3_class(
     isplit,
-    c("mc_split_inner", "mc_split", "rsplit"),
+    c("mc_split_inner", "inner_split", "mc_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -76,7 +76,7 @@ test_that("mc_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("mc_split_inner", "mc_split", "rsplit"),
+    c("mc_split_inner", "inner_split", "mc_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -111,7 +111,13 @@ test_that("group_mc_split", {
 
   expect_s3_class(
     isplit,
-    c("group_mc_split_inner", "group_mc_split", "mc_split", "rsplit"),
+    c(
+      "group_mc_split_inner",
+      "inner_split",
+      "group_mc_split",
+      "mc_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -140,7 +146,13 @@ test_that("group_mc_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("group_mc_split_inner", "group_mc_split", "mc_split", "rsplit"),
+    c(
+      "group_mc_split_inner",
+      "inner_split",
+      "group_mc_split",
+      "mc_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -174,7 +186,7 @@ test_that("vfold_split", {
 
   expect_s3_class(
     isplit,
-    c("vfold_split_inner", "vfold_split", "rsplit"),
+    c("vfold_split_inner", "inner_split", "vfold_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -203,7 +215,7 @@ test_that("vfold_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("vfold_split_inner", "vfold_split", "rsplit"),
+    c("vfold_split_inner", "inner_split", "vfold_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -238,7 +250,13 @@ test_that("group_vfold_split", {
 
   expect_s3_class(
     isplit,
-    c("group_vfold_split_inner", "group_vfold_split", "vfold_split", "rsplit"),
+    c(
+      "group_vfold_split_inner",
+      "inner_split",
+      "group_vfold_split",
+      "vfold_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -267,7 +285,13 @@ test_that("group_vfold_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("group_vfold_split_inner", "group_vfold_split", "vfold_split", "rsplit"),
+    c(
+      "group_vfold_split_inner",
+      "inner_split",
+      "group_vfold_split",
+      "vfold_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -299,7 +323,7 @@ test_that("boot_split", {
   )
   expect_s3_class(
     isplit,
-    c("boot_split_inner", "boot_split", "rsplit"),
+    c("boot_split_inner", "inner_split", "boot_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -328,7 +352,7 @@ test_that("boot_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("boot_split_inner", "boot_split", "rsplit"),
+    c("boot_split_inner", "inner_split", "boot_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -363,7 +387,13 @@ test_that("group_boot_split", {
 
   expect_s3_class(
     isplit,
-    c("group_boot_split_inner", "group_boot_split", "boot_split", "rsplit"),
+    c(
+      "group_boot_split_inner",
+      "inner_split",
+      "group_boot_split",
+      "boot_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -392,7 +422,13 @@ test_that("group_boot_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("group_boot_split_inner", "group_boot_split", "boot_split", "rsplit"),
+    c(
+      "group_boot_split_inner",
+      "inner_split",
+      "group_boot_split",
+      "boot_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -430,7 +466,7 @@ test_that("initial_validation_split", {
 
   expect_s3_class(
     isplit,
-    c("val_split_inner", "val_split", "rsplit"),
+    c("val_split_inner", "inner_split", "val_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -460,7 +496,7 @@ test_that("val_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("val_split_inner", "val_split", "rsplit"),
+    c("val_split_inner", "inner_split", "val_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -500,7 +536,13 @@ test_that("group_initial_validation_split", {
 
   expect_s3_class(
     isplit,
-    c("group_val_split_inner", "group_val_split", "val_split", "rsplit"),
+    c(
+      "group_val_split_inner",
+      "inner_split",
+      "group_val_split",
+      "val_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -534,7 +576,13 @@ test_that("group_val_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("group_val_split_inner", "group_val_split", "val_split", "rsplit"),
+    c(
+      "group_val_split_inner",
+      "inner_split",
+      "group_val_split",
+      "val_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -569,7 +617,13 @@ test_that("initial_validation_time_split", {
 
   expect_s3_class(
     isplit,
-    c("time_val_split_inner", "time_val_split", "val_split", "rsplit"),
+    c(
+      "time_val_split_inner",
+      "inner_split",
+      "time_val_split",
+      "val_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -599,7 +653,13 @@ test_that("time_val_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("time_val_split_inner", "time_val_split", "val_split", "rsplit"),
+    c(
+      "time_val_split_inner",
+      "inner_split",
+      "time_val_split",
+      "val_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -633,7 +693,7 @@ test_that("clustering_split", {
 
   expect_s3_class(
     isplit,
-    c("clustering_split_inner", "clustering_split", "rsplit"),
+    c("clustering_split_inner", "inner_split", "clustering_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -662,7 +722,7 @@ test_that("clustering_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("clustering_split_inner", "clustering_split", "rsplit"),
+    c("clustering_split_inner", "inner_split", "clustering_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -692,7 +752,7 @@ test_that("apparent_split", {
 
   expect_s3_class(
     isplit,
-    c("apparent_split_inner", "apparent_split", "rsplit"),
+    c("apparent_split_inner", "inner_split", "apparent_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -736,7 +796,12 @@ test_that("sliding_window_split", {
 
   expect_s3_class(
     isplit,
-    c("sliding_window_split_inner", "sliding_window_split", "rsplit"),
+    c(
+      "sliding_window_split_inner",
+      "inner_split",
+      "sliding_window_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -764,7 +829,12 @@ test_that("sliding_window_split needs at least 2 observations", {
 
   expect_s3_class(
     isplit,
-    c("sliding_window_split_inner", "sliding_window_split", "rsplit"),
+    c(
+      "sliding_window_split_inner",
+      "inner_split",
+      "sliding_window_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -862,7 +932,12 @@ test_that("sliding_index_split", {
 
   expect_s3_class(
     isplit,
-    c("sliding_index_split_inner", "sliding_index_split", "rsplit"),
+    c(
+      "sliding_index_split_inner",
+      "inner_split",
+      "sliding_index_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -934,7 +1009,12 @@ test_that("sliding_index_split needs at least 2 observations", {
 
   expect_s3_class(
     isplit,
-    c("sliding_index_split_inner", "sliding_index_split", "rsplit"),
+    c(
+      "sliding_index_split_inner",
+      "inner_split",
+      "sliding_index_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -1034,7 +1114,12 @@ test_that("sliding_period_split", {
 
   expect_s3_class(
     i_split,
-    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    c(
+      "sliding_period_split_inner",
+      "inner_split",
+      "sliding_period_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -1078,7 +1163,12 @@ test_that("sliding_period_split needs at least 2 observations", {
 
   expect_s3_class(
     isplit,
-    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    c(
+      "sliding_period_split_inner",
+      "inner_split",
+      "sliding_period_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -1107,7 +1197,12 @@ test_that("sliding_period_split needs observations in at least 2 periods", {
 
   expect_s3_class(
     isplit,
-    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    c(
+      "sliding_period_split_inner",
+      "inner_split",
+      "sliding_period_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 
@@ -1134,7 +1229,12 @@ test_that("sliding_period_split needs observations in at least 2 periods", {
 
   expect_s3_class(
     isplit,
-    c("sliding_period_split_inner", "sliding_period_split", "rsplit"),
+    c(
+      "sliding_period_split_inner",
+      "inner_split",
+      "sliding_period_split",
+      "rsplit"
+    ),
     exact = TRUE
   )
 })
@@ -1164,7 +1264,7 @@ test_that("initial_split", {
 
   expect_s3_class(
     isplit,
-    c("mc_split_inner", "initial_split", "mc_split", "rsplit"),
+    c("mc_split_inner", "inner_split", "initial_split", "mc_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -1194,6 +1294,7 @@ test_that("group_initial_split", {
     isplit,
     c(
       "group_mc_split_inner",
+      "inner_split",
       "group_initial_split",
       "initial_split",
       "group_mc_split",
@@ -1229,6 +1330,7 @@ test_that("initial_time_split", {
     isplit,
     c(
       "initial_time_split_inner",
+      "inner_split",
       "initial_time_split",
       "initial_split",
       "rsplit"
@@ -1261,6 +1363,7 @@ test_that("initial_time_split can create mock split", {
     isplit,
     c(
       "initial_time_split_inner",
+      "inner_split",
       "initial_time_split",
       "initial_split",
       "rsplit"
@@ -1295,7 +1398,7 @@ test_that("initial_validation_split", {
 
   expect_s3_class(
     isplit,
-    c("initial_validation_split_inner", "mc_split", "rsplit"),
+    c("initial_validation_split_inner", "inner_split", "mc_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -1323,7 +1426,7 @@ test_that("initial_validation_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("initial_validation_split_inner", "mc_split", "rsplit"),
+    c("initial_validation_split_inner", "inner_split", "mc_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -1356,6 +1459,7 @@ test_that("group_initial_validation_split", {
     isplit,
     c(
       "group_initial_validation_split_inner",
+      "inner_split",
       "group_mc_split",
       "mc_split",
       "rsplit"
@@ -1393,6 +1497,7 @@ test_that("group_initial_validation_split can create mock split", {
     isplit,
     c(
       "group_initial_validation_split_inner",
+      "inner_split",
       "group_mc_split",
       "mc_split",
       "rsplit"
@@ -1427,7 +1532,7 @@ test_that("initial_validation_time_split", {
 
   expect_s3_class(
     isplit,
-    c("initial_validation_time_split_inner", "rsplit"),
+    c("initial_validation_time_split_inner", "inner_split", "rsplit"),
     exact = TRUE
   )
 })
@@ -1455,7 +1560,7 @@ test_that("initial_validation_time_split can create mock split", {
 
   expect_s3_class(
     isplit,
-    c("initial_validation_time_split_inner", "rsplit"),
+    c("initial_validation_time_split_inner", "inner_split", "rsplit"),
     exact = TRUE
   )
 })


### PR DESCRIPTION
closes #580

- [x] Make the methods for mc_split, group_mc_split, sliding_window_split, sliding_index_split, sliding_period_split use the pattern with class(x)
- [x] Make the methods type-stable for mock splits 
- [x] Add a general inner_split class 